### PR TITLE
Add configurable sampling

### DIFF
--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -89,8 +89,8 @@ CONFIG_SCHEMA = cv.Schema(
         ): cv.Schema(
             {
                 cv.Optional(CONF_MANUAL_ACTIVE, default="true"): cv.boolean,
-                cv.Optional(CONF_TIMING_BUDGET, default=10): cv.int_range(
-                    min=15, max=500
+                cv.Optional(CONF_TIMING_BUDGET, default=15): cv.one_of(
+                    15, 20, 33, 50, 100, 200, 500
                 ),
                 cv.Inclusive(
                     CONF_SENSOR_MODE,
@@ -137,13 +137,6 @@ async def setup_conf(config, key, hub):
 
 def setup_manual_mode(config, hub):
     manual = config[CONF_MANUAL]
-    if CONF_TIMING_BUDGET in manual:
-        valid_budgets = [15, 20, 33, 50, 100, 200, 500]
-        timing_budget = manual[CONF_TIMING_BUDGET]
-        if timing_budget not in valid_budgets:
-            raise cv.Invalid(
-                f"{CONF_TIMING_BUDGET} must be one of {valid_budgets}, got {timing_budget}"
-            )
     for key in manual:
         cg.add(getattr(hub, f"set_{key}")(manual[key]))
 

--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -37,7 +37,9 @@ CONF_MANUAL = "manual"
 CONF_MANUAL_ACTIVE = "manual_active"
 CONF_CALIBRATION_ACTIVE = "calibration_active"
 CONF_TIMING_BUDGET = "timing_budget"
-CONF_USE_SAMPLING = "use_sampling"
+CONF_SAMPLING = "sampling"
+CONF_SAMPLING_ACTIVE = "active"
+CONF_SAMPLING_SIZE = "size"
 CONF_ROI = "roi"
 CONF_ROI_ACTIVE = "roi_active"
 CONF_SENSOR_OFFSET_CALIBRATION = "sensor_offset_calibration"
@@ -47,7 +49,6 @@ TYPES = [
     CONF_INVERT_DIRECTION,
     CONF_ADVISED_SENSOR_ORIENTATION,
     CONF_I2C_ADDRESS,
-    CONF_USE_SAMPLING,
 ]
 CONFIG_SCHEMA = cv.Schema(
     {
@@ -55,8 +56,13 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_INVERT_DIRECTION, default="false"): cv.boolean,
         cv.Optional(CONF_RESTORE_VALUES, default="false"): cv.boolean,
         cv.Optional(CONF_ADVISED_SENSOR_ORIENTATION, default="true"): cv.boolean,
-        cv.Optional(CONF_USE_SAMPLING, default="true"): cv.boolean,
         cv.Optional(CONF_I2C_ADDRESS, default=0x29): cv.uint8_t,
+        cv.Optional(CONF_SAMPLING): cv.Schema(
+            {
+                cv.Optional(CONF_SAMPLING_ACTIVE, default="true"): cv.boolean,
+                cv.Optional(CONF_SAMPLING_SIZE, default=2): cv.uint8_t,
+            }
+        ),
         cv.Exclusive(
             CONF_CALIBRATION,
             "mode",
@@ -146,6 +152,12 @@ def setup_manual_roi(config, hub):
         cg.add(getattr(hub, f"set_{key}")(roi[key]))
 
 
+def setup_sampling(config, hub):
+    sampling = config[CONF_SAMPLING]
+    for key in sampling:
+        cg.add(getattr(hub, f"set_sampling_{key}")(sampling[key]))
+
+
 async def to_code(config):
     hub = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(hub, config)
@@ -161,3 +173,5 @@ async def to_code(config):
         setup_manual_mode(config, hub)
     if CONF_CALIBRATION in config:
         setup_calibration_mode(config, hub)
+    if CONF_SAMPLING in config:
+        setup_sampling(config, hub)

--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -38,7 +38,6 @@ CONF_MANUAL_ACTIVE = "manual_active"
 CONF_CALIBRATION_ACTIVE = "calibration_active"
 CONF_TIMING_BUDGET = "timing_budget"
 CONF_SAMPLING = "sampling"
-CONF_SAMPLING_ACTIVE = "active"
 CONF_SAMPLING_SIZE = "size"
 CONF_ROI = "roi"
 CONF_ROI_ACTIVE = "roi_active"
@@ -57,11 +56,13 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_RESTORE_VALUES, default="false"): cv.boolean,
         cv.Optional(CONF_ADVISED_SENSOR_ORIENTATION, default="true"): cv.boolean,
         cv.Optional(CONF_I2C_ADDRESS, default=0x29): cv.uint8_t,
-        cv.Optional(CONF_SAMPLING): cv.Schema(
-            {
-                cv.Optional(CONF_SAMPLING_ACTIVE, default="true"): cv.boolean,
-                cv.Optional(CONF_SAMPLING_SIZE, default=2): cv.uint8_t,
-            }
+        cv.Optional(CONF_SAMPLING, default=2): cv.Any(
+            cv.int_range(1, 255),
+            cv.Schema(
+                {
+                    cv.Optional(CONF_SAMPLING_SIZE, default=2): cv.int_range(1, 255),
+                }
+            ),
         ),
         cv.Exclusive(
             CONF_CALIBRATION,
@@ -161,8 +162,11 @@ def setup_manual_roi(config, hub):
 
 def setup_sampling(config, hub):
     sampling = config[CONF_SAMPLING]
-    for key in sampling:
-        cg.add(getattr(hub, f"set_sampling_{key}")(sampling[key]))
+    if isinstance(sampling, int):
+        cg.add(getattr(hub, f"set_sampling_{CONF_SAMPLING_SIZE}")(sampling))
+    else:
+        for key in sampling:
+            cg.add(getattr(hub, f"set_sampling_{CONF_SAMPLING_SIZE}")(sampling[key]))
 
 
 async def to_code(config):

--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -95,7 +95,7 @@ CONFIG_SCHEMA = cv.Schema(
                     CONF_SENSOR_MODE,
                     "manual_mode",
                     f"{CONF_SENSOR_MODE}, {CONF_ROI_HEIGHT}, {CONF_ROI_WIDTH} and {CONF_MANUAL_THRESHOLD} must be used together",
-                ): cv.int_range(min=-1, max=3),
+                ): cv.int_range(min=-1, max=5),
                 cv.Inclusive(
                     CONF_MANUAL_THRESHOLD,
                     "manual_mode",

--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -89,7 +89,7 @@ CONFIG_SCHEMA = cv.Schema(
             {
                 cv.Optional(CONF_MANUAL_ACTIVE, default="true"): cv.boolean,
                 cv.Optional(CONF_TIMING_BUDGET, default=10): cv.int_range(
-                    min=10, max=1000
+                    min=15, max=500
                 ),
                 cv.Inclusive(
                     CONF_SENSOR_MODE,
@@ -136,6 +136,13 @@ async def setup_conf(config, key, hub):
 
 def setup_manual_mode(config, hub):
     manual = config[CONF_MANUAL]
+    if CONF_TIMING_BUDGET in manual:
+        valid_budgets = [15, 20, 33, 50, 100, 200, 500]
+        timing_budget = manual[CONF_TIMING_BUDGET]
+        if timing_budget not in valid_budgets:
+            raise cv.Invalid(
+                f"{CONF_TIMING_BUDGET} must be one of {valid_budgets}, got {timing_budget}"
+            )
     for key in manual:
         cg.add(getattr(hub, f"set_{key}")(manual[key]))
 

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -63,10 +63,9 @@ namespace esphome
                     }
                 }
             }
-            if (sampling_active_)
-            {
-                ESP_LOGI(SETUP, "Using sampling with sampling size: %d", DISTANCES_ARRAY_SIZE);
-            }
+
+            ESP_LOGI(SETUP, "Using sampling with sampling size: %d", DISTANCES_ARRAY_SIZE);
+
             if (invert_direction_)
             {
                 ESP_LOGI(SETUP, "Inverting direction");
@@ -192,38 +191,35 @@ namespace esphome
                 return;
             }
 
-            if (sampling_active_)
+            uint16_t Distances[2][DISTANCES_ARRAY_SIZE];
+            uint16_t MinDistance;
+            uint8_t i;
+            if (DistancesTableSize[zone] < DISTANCES_ARRAY_SIZE)
             {
-                uint16_t Distances[2][DISTANCES_ARRAY_SIZE];
-                uint16_t MinDistance;
-                uint8_t i;
-                if (DistancesTableSize[zone] < DISTANCES_ARRAY_SIZE)
-                {
-                    Distances[zone][DistancesTableSize[zone]] = distance;
-                    DistancesTableSize[zone]++;
-                    ESP_LOGD(SETUP, "Distances[%d][DistancesTableSize[zone]] = %d", zone, Distances[zone][DistancesTableSize[zone]]);
-                }
-                else
-                {
-                    for (i = 1; i < DISTANCES_ARRAY_SIZE; i++)
-                        Distances[zone][i - 1] = Distances[zone][i];
-                    Distances[zone][DISTANCES_ARRAY_SIZE - 1] = distance;
-                    ESP_LOGD(SETUP, "Distances[%d][DISTANCES_ARRAY_SIZE - 1] = %d", zone, Distances[zone][DISTANCES_ARRAY_SIZE - 1]);
-                }
-                ESP_LOGD(SETUP, "Distances[%d][0]] = %d", zone, Distances[zone][0]);
-                ESP_LOGD(SETUP, "Distances[%d][1]] = %d", zone, Distances[zone][1]);
-                // pick up the min distance
-                MinDistance = Distances[zone][0];
-                if (DistancesTableSize[zone] >= 2)
-                {
-                    for (i = 1; i < DistancesTableSize[zone]; i++)
-                    {
-                        if (Distances[zone][i] < MinDistance)
-                            MinDistance = Distances[zone][i];
-                    }
-                }
-                distance = MinDistance;
+                Distances[zone][DistancesTableSize[zone]] = distance;
+                DistancesTableSize[zone]++;
+                ESP_LOGD(SETUP, "Distances[%d][DistancesTableSize[zone]] = %d", zone, Distances[zone][DistancesTableSize[zone]]);
             }
+            else
+            {
+                for (i = 1; i < DISTANCES_ARRAY_SIZE; i++)
+                    Distances[zone][i - 1] = Distances[zone][i];
+                Distances[zone][DISTANCES_ARRAY_SIZE - 1] = distance;
+                ESP_LOGD(SETUP, "Distances[%d][DISTANCES_ARRAY_SIZE - 1] = %d", zone, Distances[zone][DISTANCES_ARRAY_SIZE - 1]);
+            }
+            ESP_LOGD(SETUP, "Distances[%d][0]] = %d", zone, Distances[zone][0]);
+            ESP_LOGD(SETUP, "Distances[%d][1]] = %d", zone, Distances[zone][1]);
+            // pick up the min distance
+            MinDistance = Distances[zone][0];
+            if (DistancesTableSize[zone] >= 2)
+            {
+                for (i = 1; i < DistancesTableSize[zone]; i++)
+                {
+                    if (Distances[zone][i] < MinDistance)
+                        MinDistance = Distances[zone][i];
+                }
+            }
+            distance = MinDistance;
 
             // PathTrack algorithm
             if (distance < DIST_THRESHOLD_MAX[zone] && distance > DIST_THRESHOLD_MIN[zone])

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -63,20 +63,25 @@ namespace esphome
                     }
                 }
             }
-
+            if (sampling_active_)
+            {
+                ESP_LOGI(SETUP, "Using sampling with sampling size: %d", DISTANCES_ARRAY_SIZE);
+            }
             if (invert_direction_)
             {
-                ESP_LOGD(TAG, "Inverting direction");
+                ESP_LOGI(SETUP, "Inverting direction");
                 LEFT = 1;
                 RIGHT = 0;
             }
             if (calibration_active_)
             {
+                ESP_LOGI(SETUP, "Calibrating sensor");
                 calibration(distanceSensor);
                 App.feed_wdt();
             }
             if (manual_active_)
             {
+                ESP_LOGI(SETUP, "Manual sensor configuration");
                 center[0] = 167;
                 center[1] = 231;
                 distanceSensor.SetROI(Roode::roi_width_, Roode::roi_height_);
@@ -91,7 +96,7 @@ namespace esphome
                 peopleCounter = EEPROM.read(100);
                 if (peopleCounter == 255) // 255 is the default value if no value was stored
                     peopleCounter = 0;
-                ESP_LOGD("Roode setup", "last value: %u", peopleCounter);
+                ESP_LOGI("Roode setup", "last value: %u", peopleCounter);
             }
             sendCounter(peopleCounter);
             distanceSensor.SetInterMeasurementInMs(delay_between_measurements);
@@ -187,10 +192,9 @@ namespace esphome
                 return;
             }
 
-            if (use_sampling_)
+            if (sampling_active_)
             {
-                ESP_LOGD(SETUP, "Using sampling");
-                static uint16_t Distances[2][DISTANCES_ARRAY_SIZE];
+                uint16_t Distances[2][DISTANCES_ARRAY_SIZE];
                 uint16_t MinDistance;
                 uint8_t i;
                 if (DistancesTableSize[zone] < DISTANCES_ARRAY_SIZE)

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -77,7 +77,6 @@ namespace esphome
       void set_invert_direction(bool dir) { invert_direction_ = dir; }
       void set_restore_values(bool val) { restore_values_ = val; }
       void set_advised_sensor_orientation(bool val) { advised_sensor_orientation_ = val; }
-      void set_sampling_active(bool val) { sampling_active_ = val; }
       void set_sampling_size(uint8_t size) { DISTANCES_ARRAY_SIZE = size; }
       void set_distance_sensor(sensor::Sensor *distance_sensor_) { distance_sensor = distance_sensor_; }
       void set_people_counter_sensor(sensor::Sensor *people_counter_sensor_) { people_counter_sensor = people_counter_sensor_; }

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -139,7 +139,7 @@ namespace esphome
       int sensor_mode{-1};
       bool advised_sensor_orientation_{true};
       bool sampling_active_{false};
-      uint8_t DISTANCES_ARRAY_SIZE;
+      uint8_t DISTANCES_ARRAY_SIZE{2};
       uint8_t address_ = 0x29;
       bool invert_direction_{false};
       bool restore_values_{false};

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -21,7 +21,6 @@ namespace esphome
 #define VL53L1X_ULD_I2C_ADDRESS 0x52 // Default address is 0x52
     static int LEFT = 0;
     static int RIGHT = 1;
-    static const uint16_t DISTANCES_ARRAY_SIZE = 2;
 
     /*
     ##### CALIBRATION #####
@@ -78,7 +77,8 @@ namespace esphome
       void set_invert_direction(bool dir) { invert_direction_ = dir; }
       void set_restore_values(bool val) { restore_values_ = val; }
       void set_advised_sensor_orientation(bool val) { advised_sensor_orientation_ = val; }
-      void set_use_sampling(bool val) { use_sampling_ = val; }
+      void set_sampling_active(bool val) { sampling_active_ = val; }
+      void set_sampling_size(uint8_t size) { DISTANCES_ARRAY_SIZE = size; }
       void set_distance_sensor(sensor::Sensor *distance_sensor_) { distance_sensor = distance_sensor_; }
       void set_people_counter_sensor(sensor::Sensor *people_counter_sensor_) { people_counter_sensor = people_counter_sensor_; }
       void set_max_threshold_zone0_sensor(sensor::Sensor *max_threshold_zone0_sensor_) { max_threshold_zone0_sensor = max_threshold_zone0_sensor_; }
@@ -138,7 +138,8 @@ namespace esphome
       int sensor_xtalk_calibration_{-1};
       int sensor_mode{-1};
       bool advised_sensor_orientation_{true};
-      bool use_sampling_{true};
+      bool sampling_active_{false};
+      uint8_t DISTANCES_ARRAY_SIZE;
       uint8_t address_ = 0x29;
       bool invert_direction_{false};
       bool restore_values_{false};

--- a/peopleCounter.yaml
+++ b/peopleCounter.yaml
@@ -86,7 +86,6 @@ roode:
   #   manual_threshold: 1280
   #   timing_budget: 200
   sampling:
-    active: true
     size: 3
   invert_direction: true
   restore_values: false

--- a/peopleCounter.yaml
+++ b/peopleCounter.yaml
@@ -73,17 +73,21 @@ roode:
   i2c_address: 0x29
   update_interval: 10ms
   # roi:
-  #   roi_height: 16
-  #   roi_width: 6
+    # roi_height: 16
+    # roi_width: 6
   calibration:
     max_threshold_percentage: 85
     min_threshold_percentage: 5
     roi_calibration: true
+    # sensor_offset_calibration: 8
+    # sensor_xtalk_calibration: 53406
   # manual:
   #   sensor_mode: 3
   #   manual_threshold: 1280
   #   timing_budget: 200
-  # use_sampling: true
+  sampling:
+    active: true
+    size: 3
   invert_direction: true
   restore_values: false
 

--- a/peopleCounter32.yaml
+++ b/peopleCounter32.yaml
@@ -76,17 +76,21 @@ roode:
   i2c_address: 0x29
   update_interval: 10ms
   # roi:
-  #   roi_height: 16
-  #   roi_width: 6
+    # roi_height: 16
+    # roi_width: 6
   calibration:
     max_threshold_percentage: 85
     min_threshold_percentage: 5
     roi_calibration: true
+    # sensor_offset_calibration: 8
+    # sensor_xtalk_calibration: 53406
   # manual:
   #   sensor_mode: 3
   #   manual_threshold: 1280
   #   timing_budget: 200
-  # use_sampling: true
+  sampling:
+    active: true
+    size: 3
   invert_direction: true
   restore_values: false
 

--- a/peopleCounter32.yaml
+++ b/peopleCounter32.yaml
@@ -89,7 +89,6 @@ roode:
   #   manual_threshold: 1280
   #   timing_budget: 200
   sampling:
-    active: true
     size: 3
   invert_direction: true
   restore_values: false

--- a/peopleCounterDev.yaml
+++ b/peopleCounterDev.yaml
@@ -74,9 +74,7 @@ roode:
   #   sensor_mode: 3
   #   manual_threshold: 1280
   #   timing_budget: 200
-  sampling:
-    active: true
-    size: 3
+  # sampling: 3
   invert_direction: true
   restore_values: false
 

--- a/peopleCounterDev.yaml
+++ b/peopleCounterDev.yaml
@@ -62,17 +62,21 @@ roode:
   i2c_address: 0x29
   update_interval: 10ms
   # roi:
-  #   roi_height: 16
-  #   roi_width: 6
+  # roi_height: 16
+  # roi_width: 6
   calibration:
     max_threshold_percentage: 85
     min_threshold_percentage: 5
     roi_calibration: true
+    # sensor_offset_calibration: 8
+    # sensor_xtalk_calibration: 53406
   # manual:
   #   sensor_mode: 3
   #   manual_threshold: 1280
   #   timing_budget: 200
-  # use_sampling: true
+  sampling:
+    active: true
+    size: 3
   invert_direction: true
   restore_values: false
 
@@ -94,8 +98,6 @@ sensor:
       name: $friendly_name people counter
     distance_sensor:
       name: $friendly_name distance
-      filters:
-        - delta: 100.0
     max_threshold_zone0:
       name: $friendly_name max zone 0
     max_threshold_zone1:


### PR DESCRIPTION
Make sampling configurable with a default of 2. This is another configuration change:

```
roode:
  id: roode_platform
  i2c_address: 0x29
  update_interval: 10ms
  # roi:
    # roi_height: 16
    # roi_width: 6
  calibration:
    max_threshold_percentage: 85
    min_threshold_percentage: 5
    roi_calibration: true
    # sensor_offset_calibration: 8
    # sensor_xtalk_calibration: 53406
  # manual:
  #   sensor_mode: 3
  #   manual_threshold: 1280
  #   timing_budget: 200
  sampling:
    active: true
    size: 3
  invert_direction: true
  restore_values: false
```