### PR TITLE
Refactor people counter to a number component

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ number:
   - platform: roode
     people_counter:
       name: People Count
-      restore_value: true
 ```
 
 ### Configuration variables

--- a/README.md
+++ b/README.md
@@ -86,7 +86,12 @@ roode:
   #   manual_threshold: 1300
   #   timing_budget: 100
   invert_direction: true
-  restore_values: false
+
+number:
+  - platform: roode
+    people_counter:
+      name: People Count
+      restore_value: true
 ```
 
 ### Configuration variables
@@ -105,7 +110,6 @@ roode:
     - Options: `0=short`, `1=long`, `2=max`. Defaults to `true`.
   - **timing_budget (optional, int)**: The timing budget for the sensor. Increasing this slows down detection but increases accuracy. Min: `10ms` Max: `1000s`. Defaults to `10ms`.
 - **invert_direction (Optional, bool)**: Inverts the counting direction. Switch to `true` if the movement count appears backwards. Defaults to `false`.
-- **restore_values (Optional, bool)**: Enables the restoration of the last count, after a reboot occurs. Defaults to `false`.
 - **advised_sensor_orientation(Optional, bool)**: Advised orientation has the two sensor pads parallel to the entryway.
                                                   So `false` means the pads are perpendicular to the entryway.
                                                   Defaults to `true`.
@@ -125,9 +129,6 @@ binary_sensor:
 sensor:
   - platform: roode
     id: hallway
-    people_counter_sensor:
-      id: peopleCounter
-      name: $friendly_name people counter
     distance_sensor:
       name: $friendly_name distance
       filters:

--- a/components/persisted_number/__init__.py
+++ b/components/persisted_number/__init__.py
@@ -12,7 +12,7 @@ PersistedNumber = number.number_ns.class_("PersistedNumber", number.Number, cg.C
 
 PERSISTED_NUMBER_SCHEMA = number.NUMBER_SCHEMA.extend({
     cv.GenerateID(): cv.declare_id(PersistedNumber),
-    cv.Optional(CONF_RESTORE_VALUE): cv.boolean,
+    cv.Optional(CONF_RESTORE_VALUE, default=True): cv.boolean,
 })
 
 

--- a/components/persisted_number/__init__.py
+++ b/components/persisted_number/__init__.py
@@ -1,0 +1,24 @@
+from typing import Optional, OrderedDict
+
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import number
+from esphome.const import (
+    CONF_ID,
+    CONF_RESTORE_VALUE,
+)
+
+PersistedNumber = number.number_ns.class_("PersistedNumber", number.Number, cg.Component)
+
+PERSISTED_NUMBER_SCHEMA = number.NUMBER_SCHEMA.extend({
+    cv.GenerateID(): cv.declare_id(PersistedNumber),
+    cv.Optional(CONF_RESTORE_VALUE): cv.boolean,
+})
+
+
+async def new_persisted_number(config: OrderedDict, min_value: float, max_value: float, step: Optional[float] = None):
+    var = await number.new_number(config, min_value=min_value, max_value=max_value, step=step)
+    await cg.register_component(var, config)
+    if CONF_RESTORE_VALUE in config:
+        cg.add(var.set_restore_value(config[CONF_RESTORE_VALUE]))
+    return var

--- a/components/persisted_number/persisted_number.cpp
+++ b/components/persisted_number/persisted_number.cpp
@@ -1,0 +1,39 @@
+#include "persisted_number.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace number {
+
+// Same as parent just changed log statement from debug to info
+auto PersistedNumber::publish_state(float state) -> void {
+    this->has_state_ = true;
+    this->state = state;
+    ESP_LOGI("number", "'%s': Sending state %f", this->get_name().c_str(), state);
+    this->state_callback_.call(state);
+}
+
+auto PersistedNumber::control(float newValue) -> void {
+    this->publish_state(newValue);
+    if (this->restore_value_) {
+        this->pref_.save(&newValue);
+    }
+}
+
+auto PersistedNumber::setup() -> void {
+    float value;
+    if (!this->restore_value_) {
+        value = 0;
+    } else {
+        this->pref_ = global_preferences->make_preference<float>(this->get_object_id_hash());
+        if (this->pref_.load(&value)) {
+            ESP_LOGI("number", "'%s': Restored state %f", this->get_name().c_str(), value);
+        } else {
+            ESP_LOGI("number", "'%s': No previous state found", this->get_name().c_str());
+            value = 0;
+        }
+    }
+    this->publish_state(value);
+}
+
+}
+}

--- a/components/persisted_number/persisted_number.cpp
+++ b/components/persisted_number/persisted_number.cpp
@@ -22,14 +22,14 @@ auto PersistedNumber::control(float newValue) -> void {
 auto PersistedNumber::setup() -> void {
     float value;
     if (!this->restore_value_) {
-        value = 0;
+        value = this->traits.get_min_value();
     } else {
         this->pref_ = global_preferences->make_preference<float>(this->get_object_id_hash());
         if (this->pref_.load(&value)) {
             ESP_LOGI("number", "'%s': Restored state %f", this->get_name().c_str(), value);
         } else {
             ESP_LOGI("number", "'%s': No previous state found", this->get_name().c_str());
-            value = 0;
+            value = this->traits.get_min_value();
         }
     }
     this->publish_state(value);

--- a/components/persisted_number/persisted_number.cpp
+++ b/components/persisted_number/persisted_number.cpp
@@ -4,14 +4,6 @@
 namespace esphome {
 namespace number {
 
-// Same as parent just changed log statement from debug to info
-auto PersistedNumber::publish_state(float state) -> void {
-    this->has_state_ = true;
-    this->state = state;
-    ESP_LOGI("number", "'%s': Sending state %f", this->get_name().c_str(), state);
-    this->state_callback_.call(state);
-}
-
 auto PersistedNumber::control(float newValue) -> void {
     this->publish_state(newValue);
     if (this->restore_value_) {

--- a/components/persisted_number/persisted_number.h
+++ b/components/persisted_number/persisted_number.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "esphome/components/number/number.h"
+#include "esphome/core/component.h"
+#include "esphome/core/preferences.h"
+
+namespace esphome {
+namespace number {
+
+class PersistedNumber : public number::Number, public Component {
+public:
+    float get_setup_priority() const override { return setup_priority::HARDWARE; }
+    void set_restore_value(bool restore) { this->restore_value_ = restore; }
+    void setup() override;
+    void publish_state(float state);
+
+protected:
+    void control(float value) override;
+
+    bool restore_value_{false};
+    ESPPreferenceObject pref_;
+};
+
+} // namespace roode
+} // namespace esphome

--- a/components/persisted_number/persisted_number.h
+++ b/components/persisted_number/persisted_number.h
@@ -12,7 +12,6 @@ public:
     float get_setup_priority() const override { return setup_priority::HARDWARE; }
     void set_restore_value(bool restore) { this->restore_value_ = restore; }
     void setup() override;
-    void publish_state(float state);
 
 protected:
     void control(float value) override;

--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -1,18 +1,13 @@
 from re import I
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import sensor
 from esphome.const import (
     CONF_ID,
-    DEVICE_CLASS_EMPTY,
-    STATE_CLASS_MEASUREMENT,
-    UNIT_EMPTY,
-    UNIT_METER,
 )
 
 
 # DEPENDENCIES = ["i2c"]
-AUTO_LOAD = ["sensor", "binary_sensor", "text_sensor"]
+AUTO_LOAD = ["sensor", "binary_sensor", "text_sensor", "number"]
 MULTI_CONF = True
 
 CONF_ROODE_ID = "roode_id"
@@ -30,7 +25,6 @@ CONF_MAX_THRESHOLD_PERCENTAGE = "max_threshold_percentage"
 CONF_MIN_THRESHOLD_PERCENTAGE = "min_threshold_percentage"
 CONF_MANUAL_THRESHOLD = "manual_threshold"
 CONF_THRESHOLD_PERCENTAGE = "threshold_percentage"
-CONF_RESTORE_VALUES = "restore_values"
 CONF_I2C_ADDRESS = "i2c_address"
 CONF_SENSOR_MODE = "sensor_mode"
 CONF_MANUAL = "manual"
@@ -44,16 +38,15 @@ CONF_ROI_ACTIVE = "roi_active"
 CONF_SENSOR_OFFSET_CALIBRATION = "sensor_offset_calibration"
 CONF_SENSOR_XTALK_CALIBRATION = "sensor_xtalk_calibration"
 TYPES = [
-    CONF_RESTORE_VALUES,
     CONF_INVERT_DIRECTION,
     CONF_ADVISED_SENSOR_ORIENTATION,
     CONF_I2C_ADDRESS,
 ]
+
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(Roode),
         cv.Optional(CONF_INVERT_DIRECTION, default="false"): cv.boolean,
-        cv.Optional(CONF_RESTORE_VALUES, default="false"): cv.boolean,
         cv.Optional(CONF_ADVISED_SENSOR_ORIENTATION, default="true"): cv.boolean,
         cv.Optional(CONF_I2C_ADDRESS, default=0x29): cv.uint8_t,
         cv.Optional(CONF_SAMPLING, default=2): cv.Any(
@@ -165,7 +158,6 @@ def setup_sampling(config, hub):
 async def to_code(config):
     hub = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(hub, config)
-    cg.add_library("EEPROM", None)
     cg.add_library("Wire", None)
     cg.add_library("rneurink", "1.2.3", "VL53L1X_ULD")
 

--- a/components/roode/number.py
+++ b/components/roode/number.py
@@ -1,0 +1,43 @@
+from typing import OrderedDict
+
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ICON,
+    CONF_MAX_VALUE
+)
+from esphome.cpp_generator import MockObj
+
+from components.persisted_number import PERSISTED_NUMBER_SCHEMA, new_persisted_number
+from . import Roode, CONF_ROODE_ID
+
+DEPENDENCIES = ["roode"]
+AUTO_LOAD = ["number", "persisted_number"]
+
+CONF_PEOPLE_COUNTER = "people_counter"
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_ROODE_ID): cv.use_id(Roode),
+        cv.Optional(CONF_PEOPLE_COUNTER): PERSISTED_NUMBER_SCHEMA.extend({
+            cv.Optional(CONF_ICON, default="mdi:counter"): cv.icon,  # new default
+            cv.Optional(CONF_MAX_VALUE, 10): cv.int_range(1, 255),
+        }),
+    }
+)
+
+
+async def setup_people_counter(config: OrderedDict, hub: MockObj):
+    counter = await new_persisted_number(
+        config,
+        min_value=0,
+        step=1,
+        max_value=config[CONF_MAX_VALUE]
+    )
+    cg.add(hub.set_people_counter(counter))
+
+
+async def to_code(config: OrderedDict):
+    hub = await cg.get_variable(config[CONF_ROODE_ID])
+    if CONF_PEOPLE_COUNTER in config:
+        await setup_people_counter(config[CONF_PEOPLE_COUNTER], hub)

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -290,10 +290,7 @@ namespace esphome
                             ESP_LOGD("Roode pathTracking", "Exit detected.");
                             DistancesTableSize[0] = 0;
                             DistancesTableSize[1] = 0;
-                            if (this->people_counter != nullptr)
-                            {
-                                this->people_counter->set(this->people_counter->state - 1);
-                            }
+                            this->updateCounter(-1);
                             if (entry_exit_event_sensor != nullptr)
                             {
                                 entry_exit_event_sensor->publish_state("Exit");
@@ -303,10 +300,7 @@ namespace esphome
                         {
                             // This an entry
                             ESP_LOGD("Roode pathTracking", "Entry detected.");
-                            if (this->people_counter != nullptr)
-                            {
-                                this->people_counter->set(this->people_counter->state + 1);
-                            }
+                            this->updateCounter(1);
                             if (entry_exit_event_sensor != nullptr)
                             {
                                 entry_exit_event_sensor->publish_state("Entry");
@@ -346,7 +340,15 @@ namespace esphome
                 }
             }
         }
-
+        void Roode::updateCounter(int delta) {
+            if (this->people_counter == nullptr)
+            {
+                return;
+            }
+            auto next = this->people_counter->state + (float) delta;
+            ESP_LOGI(TAG, "Updating people count: %d", (int) next);
+            this->people_counter->set(next);
+        }
         void Roode::recalibration()
         {
             calibration(distanceSensor);

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -125,6 +125,7 @@ namespace esphome
       void publishSensorConfiguration(int DIST_THRESHOLD_ARR[2], bool isMax);
       int getOptimizedValues(int *values, int sum, int size);
       int getSum(int *values, int size);
+      void updateCounter(int delta);
       bool calibration_active_{false};
       bool manual_active_{false};
       bool roi_active_{false};

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -5,8 +5,6 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/core/application.h"
-#include "EEPROM.h"
-// #include <VL53L1X.h>
 #include "VL53L1X_ULD.h"
 #include <math.h>
 
@@ -17,7 +15,6 @@ namespace esphome
 #define NOBODY 0
 #define SOMEONE 1
 #define VERSION "v1.4.1-beta"
-#define EEPROM_SIZE 512
 #define VL53L1X_ULD_I2C_ADDRESS 0x52 // Default address is 0x52
     static int LEFT = 0;
     static int RIGHT = 1;
@@ -79,7 +76,7 @@ namespace esphome
       void set_advised_sensor_orientation(bool val) { advised_sensor_orientation_ = val; }
       void set_sampling_size(uint8_t size) { DISTANCES_ARRAY_SIZE = size; }
       void set_distance_sensor(sensor::Sensor *distance_sensor_) { distance_sensor = distance_sensor_; }
-      void set_people_counter_sensor(sensor::Sensor *people_counter_sensor_) { people_counter_sensor = people_counter_sensor_; }
+      void set_people_counter(number::Number *counter) { this->people_counter = counter; }
       void set_max_threshold_zone0_sensor(sensor::Sensor *max_threshold_zone0_sensor_) { max_threshold_zone0_sensor = max_threshold_zone0_sensor_; }
       void set_max_threshold_zone1_sensor(sensor::Sensor *max_threshold_zone1_sensor_) { max_threshold_zone1_sensor = max_threshold_zone1_sensor_; }
       void set_min_threshold_zone0_sensor(sensor::Sensor *min_threshold_zone0_sensor_) { min_threshold_zone0_sensor = min_threshold_zone0_sensor_; }
@@ -92,7 +89,6 @@ namespace esphome
       void set_entry_exit_event_text_sensor(text_sensor::TextSensor *entry_exit_event_sensor_) { entry_exit_event_sensor = entry_exit_event_sensor_; }
       void set_sensor_mode(int sensor_mode_) { sensor_mode = sensor_mode_; }
       void getZoneDistance();
-      void sendCounter(uint16_t counter);
       void recalibration();
       bool handleSensorStatus();
       uint16_t getDistance();
@@ -110,7 +106,7 @@ namespace esphome
     protected:
       VL53L1X_ULD distanceSensor;
       sensor::Sensor *distance_sensor;
-      sensor::Sensor *people_counter_sensor;
+      number::Number *people_counter;
       sensor::Sensor *max_threshold_zone0_sensor;
       sensor::Sensor *max_threshold_zone1_sensor;
       sensor::Sensor *min_threshold_zone0_sensor;

--- a/components/roode/sensor.py
+++ b/components/roode/sensor.py
@@ -3,7 +3,6 @@ import esphome.config_validation as cv
 from esphome.components import sensor
 from esphome.const import (
     ICON_ARROW_EXPAND_VERTICAL,
-    ICON_COUNTER,
     ICON_NEW_BOX,
     ICON_RULER,
     STATE_CLASS_MEASUREMENT,
@@ -15,7 +14,6 @@ from . import Roode, CONF_ROODE_ID
 DEPENDENCIES = ["roode"]
 
 CONF_DISTANCE = "distance_sensor"
-CONF_PEOPLE_COUNTER = "people_counter_sensor"
 CONF_MAX_THRESHOLD_ZONE0 = "max_threshold_zone0"
 CONF_MAX_THRESHOLD_ZONE1 = "max_threshold_zone1"
 CONF_MIN_THRESHOLD_ZONE0 = "min_threshold_zone0"
@@ -32,12 +30,6 @@ CONFIG_SCHEMA = sensor.sensor_schema().extend(
             accuracy_decimals=0,
             state_class=STATE_CLASS_MEASUREMENT,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ),
-        cv.Optional(CONF_PEOPLE_COUNTER): sensor.sensor_schema(
-            icon=ICON_COUNTER,
-            unit_of_measurement=UNIT_EMPTY,
-            accuracy_decimals=0,
-            state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional(CONF_MAX_THRESHOLD_ZONE0): sensor.sensor_schema(
             icon="mdi:map-marker-distance",
@@ -96,9 +88,6 @@ async def to_code(config):
     if CONF_DISTANCE in config:
         distance = await sensor.new_sensor(config[CONF_DISTANCE])
         cg.add(var.set_distance_sensor(distance))
-    if CONF_PEOPLE_COUNTER in config:
-        count = await sensor.new_sensor(config[CONF_PEOPLE_COUNTER])
-        cg.add(var.set_people_counter_sensor(count))
     if CONF_MAX_THRESHOLD_ZONE0 in config:
         count = await sensor.new_sensor(config[CONF_MAX_THRESHOLD_ZONE0])
         cg.add(var.set_max_threshold_zone0_sensor(count))

--- a/peopleCounter.yaml
+++ b/peopleCounter.yaml
@@ -85,7 +85,6 @@ number:
   - platform: roode
     people_counter:
       name: $friendly_name people counter
-      restore_value: true
 
 switch:
   - platform: restart

--- a/peopleCounter.yaml
+++ b/peopleCounter.yaml
@@ -29,14 +29,6 @@ api:
   password: !secret api_password
   reboot_timeout: 60min
   services:
-    - service: set_counter
-      variables:
-        newCount: int
-      then:
-        - lambda: "id(roode_platform)->sendCounter(newCount);"
-    - service: reset_counter
-      then:
-        - lambda: "id(roode_platform)->sendCounter(0);"
     - service: recalibrate
       then:
         - lambda: "id(roode_platform)->recalibration();"
@@ -88,7 +80,12 @@ roode:
   sampling:
     size: 3
   invert_direction: true
-  restore_values: false
+
+number:
+  - platform: roode
+    people_counter:
+      name: $friendly_name people counter
+      restore_value: true
 
 switch:
   - platform: restart
@@ -103,9 +100,6 @@ binary_sensor:
 sensor:
   - platform: roode
     id: hallway
-    people_counter_sensor:
-      id: peopleCounter
-      name: $friendly_name people counter
     distance_sensor:
       name: $friendly_name distance
       filters:

--- a/peopleCounter32.yaml
+++ b/peopleCounter32.yaml
@@ -88,7 +88,6 @@ number:
   - platform: roode
     people_counter:
       name: $friendly_name people counter
-      restore_value: true
 
 switch:
   - platform: restart

--- a/peopleCounter32.yaml
+++ b/peopleCounter32.yaml
@@ -32,14 +32,6 @@ api:
   password: !secret api_password
   reboot_timeout: 60min
   services:
-    - service: set_counter
-      variables:
-        newCount: int
-      then:
-        - lambda: "id(roode_platform)->sendCounter(newCount);"
-    - service: reset_counter
-      then:
-        - lambda: "id(roode_platform)->sendCounter(0);"
     - service: recalibrate
       then:
         - lambda: "id(roode_platform)->recalibration();"
@@ -91,7 +83,12 @@ roode:
   sampling:
     size: 3
   invert_direction: true
-  restore_values: false
+
+number:
+  - platform: roode
+    people_counter:
+      name: $friendly_name people counter
+      restore_value: true
 
 switch:
   - platform: restart
@@ -106,9 +103,6 @@ binary_sensor:
 sensor:
   - platform: roode
     id: hallway
-    people_counter_sensor:
-      id: peopleCounter
-      name: $friendly_name people counter
     distance_sensor:
       name: $friendly_name distance
       filters:

--- a/peopleCounterDev.yaml
+++ b/peopleCounterDev.yaml
@@ -73,7 +73,6 @@ number:
   - platform: roode
     people_counter:
       name: $friendly_name people counter
-      restore_value: true
 
 switch:
   - platform: restart

--- a/peopleCounterDev.yaml
+++ b/peopleCounterDev.yaml
@@ -28,14 +28,6 @@ api:
   password: !secret api_password
   reboot_timeout: 60min
   services:
-    - service: set_counter
-      variables:
-        newCount: int
-      then:
-        - lambda: "id(roode_platform)->sendCounter(newCount);"
-    - service: reset_counter
-      then:
-        - lambda: "id(roode_platform)->sendCounter(0);"
     - service: recalibrate
       then:
         - lambda: "id(roode_platform)->recalibration();"
@@ -76,7 +68,12 @@ roode:
   #   timing_budget: 200
   # sampling: 3
   invert_direction: true
-  restore_values: false
+
+number:
+  - platform: roode
+    people_counter:
+      name: $friendly_name people counter
+      restore_value: true
 
 switch:
   - platform: restart
@@ -91,9 +88,6 @@ binary_sensor:
 sensor:
   - platform: roode
     id: hallway
-    people_counter_sensor:
-      id: peopleCounter
-      name: $friendly_name people counter
     distance_sensor:
       name: $friendly_name distance
     max_threshold_zone0:


### PR DESCRIPTION
This replaces the `sensor` for people counts with a `number`. Numbers are controllable which makes it much easier to change the state in HA UI & automation without having to create lambda API services.

This number is configured for people counting so min=0, step=1, max is configurable.

It is an instance of a new `PersistedNumber` object I created, that saves/restores the value using a native esphome API. This removes our explicit `EEPROM` dependency.

This flash write is debounced and can be user configured, defaults to once a minute.
https://esphome.io/components/esphome.html#adjusting-flash-writes
In testing it seems pending writes are still saved on graceful reboot.
Note that ESP8266 have this disabled by default, so...
```yaml
esp8266:
  restore_from_flash: true
```

Since this count was the only value that was persisted/"restored", I removed the `restore_values` config option in favor of `restore_value` on the number component.


~I couldn't figure out how to reference the roode platform outside of its platform setup, so for now it's just there. I suspect I just missed something and it can be moved to an independent `number` entry with the roode platform.~

```yaml
number:
  - platform: roode
    people_counter:
      name: $friendly_name people counter
      max_value: 5 # default 10
```

<img width="406" alt="Screen Shot 2022-01-01 at 6 14 54 PM" src="https://user-images.githubusercontent.com/932566/147862861-f7bb3533-aeec-4900-95af-9f8b37591539.png">

