### PR TITLE
Fix setup priority & init timeout panic

### DIFF
--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -82,7 +82,7 @@ CONFIG_SCHEMA = cv.Schema(
             }
         ),
     }
-)
+).extend(cv.COMPONENT_SCHEMA)
 
 
 async def to_code(config: Dict):

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -13,6 +13,12 @@ void Roode::setup() {
   }
   ESP_LOGI(SETUP, "Using sampling with sampling size: %d", samples);
 
+  if (this->distanceSensor->is_failed()) {
+    this->mark_failed();
+    ESP_LOGE(TAG, "Roode cannot be setup without a valid VL53L1X sensor");
+    return;
+  }
+
   calibrate_zones();
 }
 

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -58,6 +58,8 @@ class Roode : public PollingComponent {
   void update() override;
   void loop() override;
   void dump_config() override;
+  /** Roode uses data from sensors */
+  float get_setup_priority() const override { return setup_priority::PROCESSOR; };
 
   TofSensor *get_tof_sensor() { return this->distanceSensor; }
   void set_tof_sensor(TofSensor *sensor) { this->distanceSensor = sensor; }

--- a/components/vl53l1x/__init__.py
+++ b/components/vl53l1x/__init__.py
@@ -72,28 +72,35 @@ def NullableSchema(*args, default: Any = None, **kwargs):
     return cv.Any(cv.Schema(*args, **kwargs), none_to_empty)
 
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(): cv.declare_id(VL53L1X),
-        cv.Optional(CONF_PINS, default={}): NullableSchema(
-            {
-                cv.Optional(CONF_XSHUT): pins.gpio_output_pin_schema,
-                cv.Optional(CONF_INTERRUPT): pins.internal_gpio_input_pin_schema,
-            }
-        ),
-        cv.Optional(CONF_CALIBRATION, default={}): NullableSchema(
-            {
-                cv.Optional(CONF_RANGING_MODE, default=CONF_AUTO): cv.enum(
-                    RANGING_MODES
-                ),
-                cv.Optional(CONF_XTALK): cv.All(
-                    int_with_unit("corrected photon count as cps (counts per second)", "(cps)"), cv.uint16_t
-                ),
-                cv.Optional(CONF_OFFSET): cv.All(distance_as_mm, int16_t),
-            }
-        ),
-    }
-).extend(i2c.i2c_device_schema(0x29))
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(VL53L1X),
+            cv.Optional(CONF_PINS, default={}): NullableSchema(
+                {
+                    cv.Optional(CONF_XSHUT): pins.gpio_output_pin_schema,
+                    cv.Optional(CONF_INTERRUPT): pins.internal_gpio_input_pin_schema,
+                }
+            ),
+            cv.Optional(CONF_CALIBRATION, default={}): NullableSchema(
+                {
+                    cv.Optional(CONF_RANGING_MODE, default=CONF_AUTO): cv.enum(
+                        RANGING_MODES
+                    ),
+                    cv.Optional(CONF_XTALK): cv.All(
+                        int_with_unit(
+                            "corrected photon count as cps (counts per second)", "(cps)"
+                        ),
+                        cv.uint16_t,
+                    ),
+                    cv.Optional(CONF_OFFSET): cv.All(distance_as_mm, int16_t),
+                }
+            ),
+        }
+    )
+    .extend(i2c.i2c_device_schema(0x29))
+    .extend(cv.COMPONENT_SCHEMA)
+)
 
 
 async def to_code(config: Dict):

--- a/components/vl53l1x/vl53l1x.cpp
+++ b/components/vl53l1x/vl53l1x.cpp
@@ -20,31 +20,34 @@ void VL53L1X::dump_config() {
 }
 
 void VL53L1X::setup() {
+  ESP_LOGD(TAG, "Beginning setup");
+
   // TODO use xshut_pin, if given, to change address
   auto status = this->sensor.Begin(this->address_);
+  ESP_LOGD(TAG, "VL53L1_ULD begin() returned");
   if (status != VL53L1_ERROR_NONE) {
     // If the sensor could not be initialized print out the error code. -7 is timeout
-    ESP_LOGE(TAG, "Could not initialize the sensor, error code: %d", status);
+    ESP_LOGE(TAG, "Could not initialize, error code: %d", status);
     this->mark_failed();
     return;
   }
   this->address_ = sensor.GetI2CAddress();
 
   if (this->offset.has_value()) {
-    ESP_LOGI(TAG, "Setting sensor offset calibration to %d", this->offset.value());
+    ESP_LOGI(TAG, "Setting offset calibration to %d", this->offset.value());
     status = this->sensor.SetOffsetInMm(this->offset.value());
     if (status != VL53L1_ERROR_NONE) {
-      ESP_LOGE(TAG, "Could not set sensor offset calibration, error code: %d", status);
+      ESP_LOGE(TAG, "Could not set offset calibration, error code: %d", status);
       this->mark_failed();
       return;
     }
   }
 
   if (this->xtalk.has_value()) {
-    ESP_LOGI(TAG, "Setting sensor xtalk calibration to %d", this->xtalk.value());
+    ESP_LOGI(TAG, "Setting crosstalk calibration to %d", this->xtalk.value());
     status = this->sensor.SetXTalk(this->xtalk.value());
     if (status != VL53L1_ERROR_NONE) {
-      ESP_LOGE(TAG, "Could not set sensor offset calibration, error code: %d", status);
+      ESP_LOGE(TAG, "Could not set crosstalk calibration, error code: %d", status);
       this->mark_failed();
       return;
     }

--- a/components/vl53l1x/vl53l1x.h
+++ b/components/vl53l1x/vl53l1x.h
@@ -21,7 +21,7 @@ class VL53L1X : public i2c::I2CDevice, public Component {
  public:
   void setup() override;
   void dump_config() override;
-  // After GPIO, but before default...Is this needed? not sure.
+  /** This connects directly to a sensor */
   float get_setup_priority() const override { return setup_priority::DATA; };
 
   optional<uint16_t> read_distance(ROI *roi, VL53L1_Error &error);

--- a/components/vl53l1x/vl53l1x.h
+++ b/components/vl53l1x/vl53l1x.h
@@ -3,6 +3,7 @@
 
 #include "VL53L1X_ULD.h"
 #include "esphome/components/i2c/i2c.h"
+#include "esphome/core/application.h"
 #include "esphome/core/component.h"
 #include "esphome/core/gpio.h"
 #include "esphome/core/log.h"


### PR DESCRIPTION
Ensures Roode's setup comes after VL53L1X's setup, as there's a dependency there.

Also waiting for boot ourselves so we can feed watch dog, so ESPHome can gracefully continue while marking components as failed.