### PR TITLE
More fixes

### DIFF
--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -37,7 +37,7 @@ void Roode::update() {
 
 void Roode::loop() {
   // unsigned long start = micros();
-  get_alternating_zone_distances();
+  this->current_zone->readDistance(distanceSensor);
   // uint16_t samplingDistance = sampling(this->current_zone);
   path_tracking(this->current_zone);
   handle_sensor_status();
@@ -50,7 +50,6 @@ void Roode::loop() {
 }
 
 bool Roode::handle_sensor_status() {
-  ESP_LOGV(TAG, "Sensor status: %d, Last sensor status: %d", sensor_status, last_sensor_status);
   bool check_status = false;
   if (last_sensor_status != sensor_status && sensor_status == VL53L1_ERROR_NONE) {
     if (status_sensor != nullptr) {
@@ -67,12 +66,6 @@ bool Roode::handle_sensor_status() {
   last_sensor_status = sensor_status;
   sensor_status = VL53L1_ERROR_NONE;
   return check_status;
-}
-
-VL53L1_Error Roode::get_alternating_zone_distances() {
-  this->current_zone->readDistance(distanceSensor);
-  App.feed_wdt();
-  return sensor_status;
 }
 
 void Roode::path_tracking(Zone *zone) {

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -4,8 +4,12 @@ namespace esphome {
 namespace roode {
 void Roode::dump_config() {
   ESP_LOGCONFIG(TAG, "Roode:");
+  ESP_LOGCONFIG(TAG, "  Sample size: %d", samples);
   LOG_UPDATE_INTERVAL(this);
+  entry->dump_config();
+  exit->dump_config();
 }
+
 void Roode::setup() {
   ESP_LOGI(SETUP, "Booting Roode %s", VERSION);
   if (version_sensor != nullptr) {

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -241,6 +241,9 @@ void Roode::calibrateDistance() {
   entry->calibrateThreshold(distanceSensor, number_attempts);
   exit->calibrateThreshold(distanceSensor, number_attempts);
 
+  if (distanceSensor->get_ranging_mode_override().has_value()) {
+    return;
+  }
   auto *mode = determine_raning_mode(entry->threshold->idle, exit->threshold->idle);
   if (mode != initial) {
     distanceSensor->set_ranging_mode(mode);

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -120,7 +120,6 @@ class Roode : public PollingComponent {
   text_sensor::TextSensor *version_sensor;
   text_sensor::TextSensor *entry_exit_event_sensor;
 
-  VL53L1_Error get_alternating_zone_distances();
   VL53L1_Error last_sensor_status = VL53L1_ERROR_NONE;
   VL53L1_Error sensor_status = VL53L1_ERROR_NONE;
   void path_tracking(Zone *zone);

--- a/components/roode/zone.cpp
+++ b/components/roode/zone.cpp
@@ -2,6 +2,15 @@
 
 namespace esphome {
 namespace roode {
+
+void Zone::dump_config() const {
+  ESP_LOGCONFIG(TAG, "   %s", id == 0U ? "Entry" : "Exit");
+  ESP_LOGCONFIG(TAG, "     ROI: { width: %d, height: %d, center: %d }", roi->width, roi->height, roi->center);
+  ESP_LOGCONFIG(TAG, "     Threshold: { min: %dmm (%d%%), max: %dmm (%d%%), idle: %dmm }", threshold->min,
+                threshold->min_percentage.value_or((threshold->min * 100) / threshold->idle), threshold->max,
+                threshold->max_percentage.value_or((threshold->max * 100) / threshold->idle), threshold->idle);
+}
+
 VL53L1_Error Zone::readDistance(TofSensor *distanceSensor) {
   last_sensor_status = sensor_status;
 

--- a/components/roode/zone.h
+++ b/components/roode/zone.h
@@ -30,6 +30,7 @@ struct Threshold {
 class Zone {
  public:
   explicit Zone(uint8_t id) : id{id} {};
+  void dump_config() const;
   VL53L1_Error readDistance(TofSensor *distanceSensor);
   void reset_roi(uint8_t default_center);
   void calibrateThreshold(TofSensor *distanceSensor, int number_attempts);

--- a/components/vl53l1x/__init__.py
+++ b/components/vl53l1x/__init__.py
@@ -12,6 +12,7 @@ from esphome.const import (
     CONF_INTERRUPT,
     CONF_OFFSET,
     CONF_PINS,
+    CONF_TIMEOUT,
 )
 import esphome.pins as pins
 
@@ -76,6 +77,7 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(VL53L1X),
+            cv.Optional(CONF_TIMEOUT, default="2s"): cv.positive_time_period_milliseconds,
             cv.Optional(CONF_PINS, default={}): NullableSchema(
                 {
                     cv.Optional(CONF_XSHUT): pins.gpio_output_pin_schema,
@@ -125,6 +127,7 @@ async def to_code(config: Dict):
             frequency / 1000,
         )
 
+    cg.add(vl53l1x.set_timeout(config[CONF_TIMEOUT]))
     await setup_hardware(vl53l1x, config)
     await setup_calibration(vl53l1x, config[CONF_CALIBRATION])
 

--- a/components/vl53l1x/roi.h
+++ b/components/vl53l1x/roi.h
@@ -10,6 +10,9 @@ struct ROI {
   void set_width(uint8_t val) { this->width = val; }
   void set_height(uint8_t val) { this->height = val; }
   void set_center(uint8_t val) { this->center = val; }
+
+  bool operator==(const ROI &rhs) const { return width == rhs.width && height == rhs.height && center == rhs.center; }
+  bool operator!=(const ROI &rhs) const { return !(rhs == *this); }
 };
 
 }  // namespace vl53l1x

--- a/components/vl53l1x/vl53l1x.cpp
+++ b/components/vl53l1x/vl53l1x.cpp
@@ -158,11 +158,14 @@ optional<uint16_t> VL53L1X::read_distance(ROI *roi, VL53L1_Error &status) {
 
   ESP_LOGV(TAG, "Beginning distance read");
 
-  status = this->sensor.SetROI(roi->width, roi->height);
-  status += this->sensor.SetROICenter(roi->center);
-  if (status != VL53L1_ERROR_NONE) {
-    ESP_LOGE(TAG, "Could not set ROI, error code: %d", status);
-    return {};
+  if (last_roi != nullptr && *roi != *last_roi) {
+    status = this->sensor.SetROI(roi->width, roi->height);
+    status += this->sensor.SetROICenter(roi->center);
+    if (status != VL53L1_ERROR_NONE) {
+      ESP_LOGE(TAG, "Could not set ROI, error code: %d", status);
+      return {};
+    }
+    last_roi = roi;
   }
 
   status = this->sensor.StartRanging();

--- a/components/vl53l1x/vl53l1x.h
+++ b/components/vl53l1x/vl53l1x.h
@@ -46,6 +46,7 @@ class VL53L1X : public i2c::I2CDevice, public Component {
   optional<int16_t> offset{};
   optional<uint16_t> xtalk{};
   uint16_t timeout{};
+  ROI *last_roi{};
 
   VL53L1_Error init();
   VL53L1_Error wait_for_boot();

--- a/components/vl53l1x/vl53l1x.h
+++ b/components/vl53l1x/vl53l1x.h
@@ -34,6 +34,7 @@ class VL53L1X : public i2c::I2CDevice, public Component {
   void set_ranging_mode_override(const RangingMode *mode) { this->ranging_mode_override = {mode}; }
   void set_offset(int16_t val) { this->offset = val; }
   void set_xtalk(uint16_t val) { this->xtalk = val; }
+  void set_timeout(uint16_t val) { this->timeout = val; }
 
  protected:
   VL53L1X_ULD sensor;
@@ -44,6 +45,11 @@ class VL53L1X : public i2c::I2CDevice, public Component {
   optional<const RangingMode *> ranging_mode_override{};
   optional<int16_t> offset{};
   optional<uint16_t> xtalk{};
+  uint16_t timeout{};
+
+  VL53L1_Error init();
+  VL53L1_Error wait_for_boot();
+  VL53L1_Error get_device_state(uint8_t *device_state);
 };
 
 }  // namespace vl53l1x


### PR DESCRIPTION
- Fix ranging override being ignored
- Add more data to Roode's dump config call: ROI, Thresholds, Sample size
- Account for VL53L1X_ULD library shifting address to right
- Change wait for boot logic to have configurable timeout and to call ESPHome's watch dog
- Handle 255 from device state as "unknown" (device state `98`).
  - This is an undocumented result and was previously considered to be a valid boot
  - It was previously considered valid, because `255 & 1 == 1`, yet the subsequent Init call to ULD library would hang ESPHome, causing a panic loop.
 - Only set ROI to sensor if it's different from before. 
    For several subsequent reads, like in calibration, this call is unnecessary.