### PR TITLE
Fix measurements with default ROI

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,6 @@ roode:
   roi: { height: 16, width: 6 }
   # We have an experiential automatic mode that can be enabled with
   roi: auto
-  # or only automatic for one dimension
-  roi: { height: 16, width: auto }
 
   # The detection thresholds for determining whether a measurement should count as a person crossing.
   # A reading must be greater than the minimum and less than the maximum to count as a crossing.

--- a/components/roode/zone.cpp
+++ b/components/roode/zone.cpp
@@ -76,7 +76,7 @@ void Zone::roi_calibration(uint16_t entry_threshold, uint16_t exit_threshold, Or
   } else {
     // now we set the position of the center of the two zones
     if (orientation == Parallel) {
-      switch (ROI_size) {
+      switch (this->roi->width) {
         case 4:
           this->roi->center = this->id == 0U ? 150 : 247;
           break;
@@ -90,7 +90,7 @@ void Zone::roi_calibration(uint16_t entry_threshold, uint16_t exit_threshold, Or
           break;
       }
     } else {
-      switch (ROI_size) {
+      switch (this->roi->width) {
         case 4:
           this->roi->center = this->id == 0U ? 193 : 58;
           break;

--- a/components/roode/zone.cpp
+++ b/components/roode/zone.cpp
@@ -37,6 +37,8 @@ void Zone::reset_roi(uint8_t default_center) {
   roi->width = roi_override->width ?: 6;
   roi->height = roi_override->height ?: 16;
   roi->center = roi_override->center ?: default_center;
+  ESP_LOGD(TAG, "%s ROI reset: { width: %d, height: %d, center: %d }", id == 0U ? "Entry" : "Exit", roi->width,
+           roi->height, roi->center);
 }
 
 void Zone::calibrateThreshold(TofSensor *distanceSensor, int number_attempts) {

--- a/components/vl53l1x/__init__.py
+++ b/components/vl53l1x/__init__.py
@@ -77,7 +77,9 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(VL53L1X),
-            cv.Optional(CONF_TIMEOUT, default="2s"): cv.positive_time_period_milliseconds,
+            cv.Optional(
+                CONF_TIMEOUT, default="2s"
+            ): cv.positive_time_period_milliseconds,
             cv.Optional(CONF_PINS, default={}): NullableSchema(
                 {
                     cv.Optional(CONF_XSHUT): pins.gpio_output_pin_schema,


### PR DESCRIPTION
Fixes #99 

Base ROI center on the actual width used, not the just the one that's calculated. If a fixed width is used, like from config or default value, and it doesn't match the calculated one, then the ROI center set would not work.