### PR TITLE
Refactor Occupancy/Presence Sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,8 +196,15 @@ This allows the current people count to be adjusted easily via Home Assistant.
 ```yaml
 binary_sensor:
   - platform: roode
-    presence_sensor:
-      name: $friendly_name presence
+    presence:
+      name: $friendly_name Presence
+    zones:
+      entry:
+        presence:
+          name: $friendly_name Entry Presence
+      exit:
+        presence:
+          name: $friendly_name Exit Presence
 
 sensor:
   - platform: roode

--- a/ci/common.yaml
+++ b/ci/common.yaml
@@ -26,8 +26,15 @@ number:
 
 binary_sensor:
   - platform: roode
-    presence_sensor:
-      name: $friendly_name presence
+    presence:
+      name: $friendly_name Presence
+    zones:
+      entry:
+        presence:
+          name: $friendly_name Entry Presence
+      exit:
+        presence:
+          name: $friendly_name Exit Presence
 
 sensor:
   - platform: roode

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -79,7 +79,7 @@ void Roode::path_tracking(Zone *zone) {
   int AnEventHasOccured = 0;
 
   // PathTrack algorithm
-  if (zone->getMinDistance() < zone->threshold->max && zone->getMinDistance() > zone->threshold->min) {
+  if (zone->is_occupied()) {
     // Someone is in the sensing area
     CurrentZoneStatus = SOMEONE;
     if (presence_sensor != nullptr) {

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -187,8 +187,8 @@ void Roode::updateCounter(int delta) {
 }
 void Roode::recalibration() { calibrate_zones(); }
 
-const RangingMode *Roode::determine_raning_mode(uint16_t average_entry_zone_distance,
-                                                uint16_t average_exit_zone_distance) {
+const RangingMode *Roode::determine_ranging_mode(uint16_t average_entry_zone_distance,
+                                                uint16_t average_exit_zone_distance) const {
   uint16_t min = average_entry_zone_distance < average_exit_zone_distance ? average_entry_zone_distance
                                                                           : average_exit_zone_distance;
   uint16_t max = average_entry_zone_distance > average_exit_zone_distance ? average_entry_zone_distance
@@ -237,7 +237,7 @@ void Roode::calibrateDistance() {
   if (distanceSensor->get_ranging_mode_override().has_value()) {
     return;
   }
-  auto *mode = determine_raning_mode(entry->threshold->idle, exit->threshold->idle);
+  auto *mode = determine_ranging_mode(entry->threshold->idle, exit->threshold->idle);
   if (mode != initial) {
     distanceSensor->set_ranging_mode(mode);
   }

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -68,20 +68,20 @@ bool Roode::handle_sensor_status() {
   return check_status;
 }
 
-void Roode::path_tracking(Zone *zone) {
-  static int PathTrack[] = {0, 0, 0, 0};
-  static int PathTrackFillingSize = 1;  // init this to 1 as we start from state
+void Roode::path_tracking(const Zone *const zone) {
+  static int path_track[] = {0, 0, 0, 0};
+  static int path_track_filling_size = 1;  // init this to 1 as we start from state
                                         // where nobody is any of the zones
-  static int LeftPreviousStatus = NOBODY;
-  static int RightPreviousStatus = NOBODY;
-  int CurrentZoneStatus = NOBODY;
-  int AllZonesCurrentStatus = 0;
-  int AnEventHasOccured = 0;
+  static bool left_previously_occupied = false;
+  static bool right_previously_occupied = false;
+  bool current_zone_occupied = false;
+  int all_zones_current_status = 0;
+  bool an_event_has_occurred = false;
 
-  // PathTrack algorithm
+  // path_track algorithm
   if (zone->is_occupied()) {
     // Someone is in the sensing area
-    CurrentZoneStatus = SOMEONE;
+    current_zone_occupied = true;
     if (presence_sensor != nullptr) {
       presence_sensor->publish_state(true);
     }
@@ -89,57 +89,57 @@ void Roode::path_tracking(Zone *zone) {
 
   // left zone
   if (zone == (this->invert_direction_ ? this->exit : this->entry)) {
-    if (CurrentZoneStatus != LeftPreviousStatus) {
-      // event in left zone has occured
-      AnEventHasOccured = 1;
+    if (current_zone_occupied != left_previously_occupied) {
+      // event in left zone has occurred
+      an_event_has_occurred = true;
 
-      if (CurrentZoneStatus == SOMEONE) {
-        AllZonesCurrentStatus += 1;
+      if (current_zone_occupied) {
+        all_zones_current_status += 1;
       }
       // need to check right zone as well ...
-      if (RightPreviousStatus == SOMEONE) {
-        // event in right zone has occured
-        AllZonesCurrentStatus += 2;
+      if (right_previously_occupied) {
+        // event in right zone has occurred
+        all_zones_current_status += 2;
       }
       // remember for next time
-      LeftPreviousStatus = CurrentZoneStatus;
+      left_previously_occupied = current_zone_occupied;
     }
   }
   // right zone
   else {
-    if (CurrentZoneStatus != RightPreviousStatus) {
-      // event in right zone has occured
-      AnEventHasOccured = 1;
-      if (CurrentZoneStatus == SOMEONE) {
-        AllZonesCurrentStatus += 2;
+    if (current_zone_occupied != right_previously_occupied) {
+      // event in right zone has occurred
+      an_event_has_occurred = true;
+      if (current_zone_occupied) {
+        all_zones_current_status += 2;
       }
       // need to check left zone as well ...
-      if (LeftPreviousStatus == SOMEONE) {
-        // event in left zone has occured
-        AllZonesCurrentStatus += 1;
+      if (left_previously_occupied) {
+        // event in left zone has occurred
+        all_zones_current_status += 1;
       }
       // remember for next time
-      RightPreviousStatus = CurrentZoneStatus;
+      right_previously_occupied = current_zone_occupied;
     }
   }
 
-  // if an event has occured
-  if (AnEventHasOccured) {
-    ESP_LOGD(TAG, "Event has occured, AllZonesCurrentStatus: %d", AllZonesCurrentStatus);
-    if (PathTrackFillingSize < 4) {
-      PathTrackFillingSize++;
+  // if an event has occurred
+  if (an_event_has_occurred) {
+    ESP_LOGD(TAG, "Event has occurred, all_zones_current_status: %d", all_zones_current_status);
+    if (path_track_filling_size < 4) {
+      path_track_filling_size++;
     }
 
     // if nobody anywhere lets check if an exit or entry has happened
-    if ((LeftPreviousStatus == NOBODY) && (RightPreviousStatus == NOBODY)) {
-      ESP_LOGD(TAG, "Nobody anywhere, AllZonesCurrentStatus: %d", AllZonesCurrentStatus);
-      // check exit or entry only if PathTrackFillingSize is 4 (for example 0 1
-      // 3 2) and last event is 0 (nobobdy anywhere)
-      if (PathTrackFillingSize == 4) {
-        // check exit or entry. no need to check PathTrack[0] == 0 , it is
+    if (!left_previously_occupied && !right_previously_occupied) {
+      ESP_LOGD(TAG, "Nobody anywhere, all_zones_current_status: %d", all_zones_current_status);
+      // check exit or entry only if path_track_filling_size is 4 (for example 0 1
+      // 3 2) and last event is 0 (nobody anywhere)
+      if (path_track_filling_size == 4) {
+        // check exit or entry. no need to check path_track[0] == 0 , it is
         // always the case
 
-        if ((PathTrack[1] == 1) && (PathTrack[2] == 3) && (PathTrack[3] == 2)) {
+        if ((path_track[1] == 1) && (path_track[2] == 3) && (path_track[3] == 2)) {
           // This an exit
           ESP_LOGI("Roode pathTracking", "Exit detected.");
 
@@ -147,7 +147,7 @@ void Roode::path_tracking(Zone *zone) {
           if (entry_exit_event_sensor != nullptr) {
             entry_exit_event_sensor->publish_state("Exit");
           }
-        } else if ((PathTrack[1] == 2) && (PathTrack[2] == 3) && (PathTrack[3] == 1)) {
+        } else if ((path_track[1] == 2) && (path_track[2] == 3) && (path_track[3] == 1)) {
           // This an entry
           ESP_LOGI("Roode pathTracking", "Entry detected.");
           this->updateCounter(1);
@@ -157,21 +157,21 @@ void Roode::path_tracking(Zone *zone) {
         }
       }
 
-      PathTrackFillingSize = 1;
+      path_track_filling_size = 1;
     } else {
-      // update PathTrack
-      // example of PathTrack update
+      // update path_track
+      // example of path_track update
       // 0
       // 0 1
       // 0 1 3
       // 0 1 3 1
       // 0 1 3 3
       // 0 1 3 2 ==> if next is 0 : check if exit
-      PathTrack[PathTrackFillingSize - 1] = AllZonesCurrentStatus;
+      path_track[path_track_filling_size - 1] = all_zones_current_status;
     }
   }
   if (presence_sensor != nullptr) {
-    if (CurrentZoneStatus == NOBODY && LeftPreviousStatus == NOBODY && RightPreviousStatus == NOBODY) {
+    if (!current_zone_occupied && !left_previously_occupied && !right_previously_occupied) {
       // nobody is in the sensing area
       presence_sensor->publish_state(false);
     }

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -16,8 +16,6 @@ using TofSensor = esphome::vl53l1x::VL53L1X;
 
 namespace esphome {
 namespace roode {
-#define NOBODY 0
-#define SOMEONE 1
 #define VERSION "1.5.1"
 static const char *const TAG = "Roode";
 static const char *const SETUP = "Setup";
@@ -122,7 +120,7 @@ class Roode : public PollingComponent {
 
   VL53L1_Error last_sensor_status = VL53L1_ERROR_NONE;
   VL53L1_Error sensor_status = VL53L1_ERROR_NONE;
-  void path_tracking(Zone *zone);
+  void path_tracking(const Zone *zone);
   bool handle_sensor_status();
   void calibrateDistance();
   void calibrate_zones();

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -88,9 +88,7 @@ class Roode : public PollingComponent {
   void set_exit_roi_height_sensor(sensor::Sensor *roi_height_sensor_) { exit_roi_height_sensor = roi_height_sensor_; }
   void set_exit_roi_width_sensor(sensor::Sensor *roi_width_sensor_) { exit_roi_width_sensor = roi_width_sensor_; }
   void set_sensor_status_sensor(sensor::Sensor *status_sensor_) { status_sensor = status_sensor_; }
-  void set_presence_sensor_binary_sensor(binary_sensor::BinarySensor *presence_sensor_) {
-    presence_sensor = presence_sensor_;
-  }
+  void set_occupancy_sensor(binary_sensor::BinarySensor *sensor) { occupancy = sensor; }
   void set_version_text_sensor(text_sensor::TextSensor *version_sensor_) { version_sensor = version_sensor_; }
   void set_entry_exit_event_text_sensor(text_sensor::TextSensor *entry_exit_event_sensor_) {
     entry_exit_event_sensor = entry_exit_event_sensor_;
@@ -114,7 +112,7 @@ class Roode : public PollingComponent {
   sensor::Sensor *entry_roi_height_sensor;
   sensor::Sensor *entry_roi_width_sensor;
   sensor::Sensor *status_sensor;
-  binary_sensor::BinarySensor *presence_sensor;
+  binary_sensor::BinarySensor *occupancy{};
   text_sensor::TextSensor *version_sensor;
   text_sensor::TextSensor *entry_exit_event_sensor;
 

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -126,7 +126,8 @@ class Roode : public PollingComponent {
   bool handle_sensor_status();
   void calibrateDistance();
   void calibrate_zones();
-  const RangingMode *determine_raning_mode(uint16_t average_entry_zone_distance, uint16_t average_exit_zone_distance);
+  const RangingMode *determine_ranging_mode(uint16_t average_entry_zone_distance,
+                                            uint16_t average_exit_zone_distance) const;
   void publish_sensor_configuration(Zone *entry, Zone *exit, bool isMax);
   void updateCounter(int delta);
   Orientation orientation_{Parallel};

--- a/components/roode/zone.cpp
+++ b/components/roode/zone.cpp
@@ -26,6 +26,8 @@ VL53L1_Error Zone::readDistance(TofSensor *distanceSensor) {
   };
   min_distance = *std::min_element(samples.begin(), samples.end());
 
+  occupancy->publish_state(min_distance < threshold->max && min_distance > threshold->min);
+
   return sensor_status;
 }
 
@@ -125,8 +127,6 @@ int Zone::getOptimizedValues(int *values, int sum, int size) {
   ESP_LOGD(CALIBRATION, "Zone SD: %d", sd);
   return avg - sd;
 }
-
-bool Zone::is_occupied() const { return min_distance < threshold->max && min_distance > threshold->min; }
 
 uint16_t Zone::getDistance() const { return this->last_distance; }
 }  // namespace roode

--- a/components/roode/zone.cpp
+++ b/components/roode/zone.cpp
@@ -126,7 +126,8 @@ int Zone::getOptimizedValues(int *values, int sum, int size) {
   return avg - sd;
 }
 
+bool Zone::is_occupied() const { return min_distance < threshold->max && min_distance > threshold->min; }
+
 uint16_t Zone::getDistance() const { return this->last_distance; }
-uint16_t Zone::getMinDistance() const { return this->min_distance; }
 }  // namespace roode
 }  // namespace esphome

--- a/components/roode/zone.h
+++ b/components/roode/zone.h
@@ -37,11 +37,13 @@ class Zone {
   void roi_calibration(uint16_t entry_threshold, uint16_t exit_threshold, Orientation orientation);
   const uint8_t id;
   uint16_t getDistance() const;
-  bool is_occupied() const;
+  bool is_occupied() const { return occupancy->state; };
   ROI *roi = new ROI();
   ROI *roi_override = new ROI();
   Threshold *threshold = new Threshold();
   void set_max_samples(uint8_t max) { max_samples = max; };
+  binary_sensor::BinarySensor *occupancy{};
+  void set_occupancy_sensor(binary_sensor::BinarySensor *sensor) { occupancy = sensor; }
 
  protected:
   int getOptimizedValues(int *values, int sum, int size);

--- a/components/roode/zone.h
+++ b/components/roode/zone.h
@@ -37,7 +37,7 @@ class Zone {
   void roi_calibration(uint16_t entry_threshold, uint16_t exit_threshold, Orientation orientation);
   const uint8_t id;
   uint16_t getDistance() const;
-  uint16_t getMinDistance() const;
+  bool is_occupied() const;
   ROI *roi = new ROI();
   ROI *roi_override = new ROI();
   Threshold *threshold = new Threshold();

--- a/peopleCounter32.yaml
+++ b/peopleCounter32.yaml
@@ -108,7 +108,7 @@ binary_sensor:
   - platform: status
     name: $friendly_name API Status
   - platform: roode
-    presence_sensor:
+    presence:
       name: $friendly_name presence
 
 sensor:

--- a/peopleCounter32Dev.yaml
+++ b/peopleCounter32Dev.yaml
@@ -104,7 +104,7 @@ binary_sensor:
   - platform: status
     name: $friendly_name API Status
   - platform: roode
-    presence_sensor:
+    presence:
       name: $friendly_name presence
 
 sensor:

--- a/peopleCounter8266.yaml
+++ b/peopleCounter8266.yaml
@@ -96,7 +96,7 @@ binary_sensor:
   - platform: status
     name: $friendly_name API Status
   - platform: roode
-    presence_sensor:
+    presence:
       name: $friendly_name presence
 
 sensor:

--- a/peopleCounter8266Dev.yaml
+++ b/peopleCounter8266Dev.yaml
@@ -100,7 +100,7 @@ binary_sensor:
   - platform: status
     name: $friendly_name API Status
   - platform: roode
-    presence_sensor:
+    presence:
       name: $friendly_name presence
 
 sensor:


### PR DESCRIPTION
Depends on #110 

Zones now have their own occupancy/presence sensors. Roode's sensor just unions them now.

```yaml
binary_sensor:
  - platform: roode
    presence:
      name: $friendly_name Presence
    zones:
      entry:
        presence:
          name: $friendly_name Entry Presence
      exit:
        presence:
          name: $friendly_name Exit Presence
```
![example](https://user-images.githubusercontent.com/932566/150648912-b012e291-0209-4a2b-a06b-8f49a7dae7d1.gif)

