### PR TITLE
Refactor distance sensors to zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,11 +208,17 @@ binary_sensor:
 
 sensor:
   - platform: roode
-    id: hallway
-    distance_sensor:
-      name: $friendly_name distance
-      filters:
-        - delta: 100.0
+    zones:
+      entry:
+        distance:
+          name: $friendly_name Entry Distance
+          filters:
+            - delta: 100
+      exit:
+        distance:
+          name: $friendly_name Exit Distance
+          filters:
+            - delta: 100
     threshold_entry:
       name: $friendly_name Zone 0
     threshold_exit:

--- a/ci/common.yaml
+++ b/ci/common.yaml
@@ -38,11 +38,17 @@ binary_sensor:
 
 sensor:
   - platform: roode
-    id: roode_sensors
-    distance_entry:
-      name: $friendly_name distance zone 0
-    distance_exit:
-      name: $friendly_name distance zone 1
+    zones:
+      entry:
+        distance:
+          name: $friendly_name Entry Distance
+          filters:
+            - delta: 100
+      exit:
+        distance:
+          name: $friendly_name Exit Distance
+          filters:
+            - delta: 100
     max_threshold_entry:
       name: $friendly_name max zone 0
     max_threshold_exit:

--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -17,8 +17,8 @@ MULTI_CONF = True
 CONF_ROODE_ID = "roode_id"
 
 roode_ns = cg.esphome_ns.namespace("roode")
-Roode = roode_ns.class_("Roode", cg.PollingComponent)
-Zone = roode_ns.class_("Zone", cg.Component)
+Roode = roode_ns.class_("Roode", cg.Component)
+Zone = roode_ns.class_("Zone", cg.PollingComponent)
 
 CONF_AUTO = "auto"
 CONF_ORIENTATION = "orientation"
@@ -62,7 +62,7 @@ THRESHOLDS_SCHEMA = NullableSchema(
 
 ZONE_SCHEMA = cv.All(
     none_to_empty(),
-    cv.COMPONENT_SCHEMA.extend(
+    cv.polling_component_schema("100ms").extend(
         {
             cv.GenerateID(): cv.declare_id(Zone),
             cv.Optional(CONF_ROI, default={}): ROI_SCHEMA,

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -6,8 +6,6 @@ void Roode::dump_config() {
   ESP_LOGCONFIG(TAG, "Roode:");
   ESP_LOGCONFIG(TAG, "  Sample size: %d", samples);
   LOG_UPDATE_INTERVAL(this);
-  entry->dump_config();
-  exit->dump_config();
 }
 
 void Roode::setup() {
@@ -30,6 +28,8 @@ void Roode::setup() {
     entry->occupancy->add_on_state_callback(on_zone_occupancy_change);
     exit->occupancy->add_on_state_callback(on_zone_occupancy_change);
   }
+
+  current_zone = entry;
 
   calibrate_zones();
 }

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -5,7 +5,6 @@ namespace roode {
 void Roode::dump_config() {
   ESP_LOGCONFIG(TAG, "Roode:");
   ESP_LOGCONFIG(TAG, "  Sample size: %d", samples);
-  LOG_UPDATE_INTERVAL(this);
 }
 
 void Roode::setup() {
@@ -32,15 +31,6 @@ void Roode::setup() {
   current_zone = entry;
 
   calibrate_zones();
-}
-
-void Roode::update() {
-  if (distance_entry != nullptr) {
-    distance_entry->publish_state(entry->getDistance());
-  }
-  if (distance_exit != nullptr) {
-    distance_exit->publish_state(exit->getDistance());
-  }
 }
 
 void Roode::loop() {

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -23,11 +23,13 @@ void Roode::setup() {
     return;
   }
 
-  auto on_zone_occupancy_change = [this](bool state) {
-    occupancy->publish_state(entry->is_occupied() || exit->is_occupied());
-  };
-  entry->occupancy->add_on_state_callback(on_zone_occupancy_change);
-  exit->occupancy->add_on_state_callback(on_zone_occupancy_change);
+  if (occupancy != nullptr) {
+    auto on_zone_occupancy_change = [this](bool state) {
+      occupancy->publish_state(entry->is_occupied() || exit->is_occupied());
+    };
+    entry->occupancy->add_on_state_callback(on_zone_occupancy_change);
+    exit->occupancy->add_on_state_callback(on_zone_occupancy_change);
+  }
 
   calibrate_zones();
 }

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -94,8 +94,8 @@ class Roode : public PollingComponent {
     entry_exit_event_sensor = entry_exit_event_sensor_;
   }
   void recalibration();
-  Zone *entry = new Zone(0);
-  Zone *exit = new Zone(1);
+  Zone *entry;
+  Zone *exit;
 
  protected:
   TofSensor *distanceSensor;

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -50,10 +50,9 @@ static int time_budget_in_ms_medium_long = 50;
 static int time_budget_in_ms_long = 100;
 static int time_budget_in_ms_max = 200;  // max range: 4m
 
-class Roode : public PollingComponent {
+class Roode : public Component {
  public:
   void setup() override;
-  void update() override;
   void loop() override;
   void dump_config() override;
   /** Roode uses data from sensors */
@@ -68,8 +67,6 @@ class Roode : public PollingComponent {
     entry->set_max_samples(size);
     exit->set_max_samples(size);
   }
-  void set_distance_entry(sensor::Sensor *distance_entry_) { distance_entry = distance_entry_; }
-  void set_distance_exit(sensor::Sensor *distance_exit_) { distance_exit = distance_exit_; }
   void set_people_counter(number::Number *counter) { this->people_counter = counter; }
   void set_max_threshold_entry_sensor(sensor::Sensor *max_threshold_entry_sensor_) {
     max_threshold_entry_sensor = max_threshold_entry_sensor_;
@@ -100,8 +97,6 @@ class Roode : public PollingComponent {
  protected:
   TofSensor *distanceSensor;
   Zone *current_zone = entry;
-  sensor::Sensor *distance_entry;
-  sensor::Sensor *distance_exit;
   number::Number *people_counter;
   sensor::Sensor *max_threshold_entry_sensor;
   sensor::Sensor *max_threshold_exit_sensor;

--- a/components/roode/sensor.py
+++ b/components/roode/sensor.py
@@ -1,5 +1,8 @@
+from typing import Dict
+
 import esphome.codegen as cg
 import esphome.config_validation as cv
+from esphome.components.sensor import new_sensor, sensor_schema
 from esphome.components import sensor
 from esphome.const import (
     ICON_ARROW_EXPAND_VERTICAL,
@@ -9,12 +12,18 @@ from esphome.const import (
     UNIT_EMPTY,
     ENTITY_CATEGORY_DIAGNOSTIC,
 )
-from . import Roode, CONF_ROODE_ID
+from . import (
+    Roode,
+    CONF_ROODE_ID,
+    NullableSchema,
+    CONF_ZONES,
+    CONF_ENTRY_ZONE,
+    CONF_EXIT_ZONE,
+)
 
 DEPENDENCIES = ["roode"]
 
-CONF_DISTANCE_entry = "distance_entry"
-CONF_DISTANCE_exit = "distance_exit"
+CONF_DISTANCE = "distance"
 CONF_MAX_THRESHOLD_entry = "max_threshold_entry"
 CONF_MAX_THRESHOLD_exit = "max_threshold_exit"
 CONF_MIN_THRESHOLD_entry = "min_threshold_entry"
@@ -25,21 +34,26 @@ CONF_ROI_HEIGHT_exit = "roi_height_exit"
 CONF_ROI_WIDTH_exit = "roi_width_exit"
 SENSOR_STATUS = "sensor_status"
 
-CONFIG_SCHEMA = sensor.sensor_schema().extend(
+ZONE_SCHEMA = NullableSchema(
     {
-        cv.Optional(CONF_DISTANCE_entry): sensor.sensor_schema(
+        cv.Optional(CONF_DISTANCE): sensor_schema(
             icon=ICON_RULER,
             unit_of_measurement="mm",
             accuracy_decimals=0,
             state_class=STATE_CLASS_MEASUREMENT,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
-        cv.Optional(CONF_DISTANCE_exit): sensor.sensor_schema(
-            icon=ICON_RULER,
-            unit_of_measurement="mm",
-            accuracy_decimals=0,
-            state_class=STATE_CLASS_MEASUREMENT,
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    }
+)
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_ROODE_ID): cv.use_id(Roode),
+        cv.Optional(CONF_ZONES, default={}): NullableSchema(
+            {
+                cv.Optional(CONF_ENTRY_ZONE, default={}): ZONE_SCHEMA,
+                cv.Optional(CONF_EXIT_ZONE, default={}): ZONE_SCHEMA,
+            }
         ),
         cv.Optional(CONF_MAX_THRESHOLD_entry): sensor.sensor_schema(
             icon="mdi:map-marker-distance",
@@ -102,19 +116,15 @@ CONFIG_SCHEMA = sensor.sensor_schema().extend(
             accuracy_decimals=0,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
-        cv.GenerateID(CONF_ROODE_ID): cv.use_id(Roode),
     }
 )
 
 
-async def to_code(config):
+async def to_code(config: Dict):
     var = await cg.get_variable(config[CONF_ROODE_ID])
-    if CONF_DISTANCE_entry in config:
-        distance = await sensor.new_sensor(config[CONF_DISTANCE_entry])
-        cg.add(var.set_distance_entry(distance))
-    if CONF_DISTANCE_exit in config:
-        distance = await sensor.new_sensor(config[CONF_DISTANCE_exit])
-        cg.add(var.set_distance_exit(distance))
+    await to_code_zone(CONF_ENTRY_ZONE, config, var)
+    await to_code_zone(CONF_EXIT_ZONE, config, var)
+
     if CONF_MAX_THRESHOLD_entry in config:
         count = await sensor.new_sensor(config[CONF_MAX_THRESHOLD_entry])
         cg.add(var.set_max_threshold_entry_sensor(count))
@@ -142,3 +152,12 @@ async def to_code(config):
     if SENSOR_STATUS in config:
         count = await sensor.new_sensor(config[SENSOR_STATUS])
         cg.add(var.set_sensor_status_sensor(count))
+
+
+async def to_code_zone(name: str, config: Dict, roode: cg.Pvariable):
+    zone_config = config[CONF_ZONES][name]
+    zone_var = cg.MockObj(f"{roode}->{name}", "->")
+    if CONF_DISTANCE in zone_config:
+        cg.add(
+            zone_var.set_distance_sensor(await new_sensor(zone_config[CONF_DISTANCE]))
+        )

--- a/components/roode/zone.cpp
+++ b/components/roode/zone.cpp
@@ -3,10 +3,10 @@
 namespace esphome {
 namespace roode {
 
-void Zone::dump_config() const {
-  ESP_LOGCONFIG(TAG, "   %s", id == 0U ? "Entry" : "Exit");
-  ESP_LOGCONFIG(TAG, "     ROI: { width: %d, height: %d, center: %d }", roi->width, roi->height, roi->center);
-  ESP_LOGCONFIG(TAG, "     Threshold: { min: %dmm (%d%%), max: %dmm (%d%%), idle: %dmm }", threshold->min,
+void Zone::dump_config() {
+  ESP_LOGCONFIG(TAG, "%s Zone:", id == 0U ? "Entry" : "Exit");
+  ESP_LOGCONFIG(TAG, "  ROI: { width: %d, height: %d, center: %d }", roi->width, roi->height, roi->center);
+  ESP_LOGCONFIG(TAG, "  Threshold: { min: %dmm (%d%%), max: %dmm (%d%%), idle: %dmm }", threshold->min,
                 threshold->min_percentage.value_or((threshold->min * 100) / threshold->idle), threshold->max,
                 threshold->max_percentage.value_or((threshold->max * 100) / threshold->idle), threshold->idle);
 }
@@ -49,7 +49,7 @@ void Zone::calibrateThreshold(TofSensor *distanceSensor, int number_attempts) {
   int sum = 0;
   for (int i = 0; i < number_attempts; i++) {
     this->readDistance(distanceSensor);
-    zone_distances[i] = this->getDistance();
+    zone_distances[i] = last_distance;
     sum += zone_distances[i];
   };
   threshold->idle = this->getOptimizedValues(zone_distances, sum, number_attempts);
@@ -128,6 +128,10 @@ int Zone::getOptimizedValues(int *values, int sum, int size) {
   return avg - sd;
 }
 
-uint16_t Zone::getDistance() const { return this->last_distance; }
+void Zone::update() {
+  if (distance_sensor != nullptr) {
+    distance_sensor->publish_state(min_distance);
+  }
+}
 }  // namespace roode
 }  // namespace esphome

--- a/components/roode/zone.cpp
+++ b/components/roode/zone.cpp
@@ -9,6 +9,7 @@ void Zone::dump_config() {
   ESP_LOGCONFIG(TAG, "  Threshold: { min: %dmm (%d%%), max: %dmm (%d%%), idle: %dmm }", threshold->min,
                 threshold->min_percentage.value_or((threshold->min * 100) / threshold->idle), threshold->max,
                 threshold->max_percentage.value_or((threshold->max * 100) / threshold->idle), threshold->idle);
+  LOG_UPDATE_INTERVAL(this);
 }
 
 VL53L1_Error Zone::readDistance(TofSensor *distanceSensor) {

--- a/components/roode/zone.h
+++ b/components/roode/zone.h
@@ -27,16 +27,16 @@ struct Threshold {
   void set_max_percentage(uint8_t max) { this->max_percentage = max; }
 };
 
-class Zone : public Component {
+class Zone : public PollingComponent {
  public:
-  explicit Zone(uint8_t id) : id{id} {};
+  explicit Zone(uint8_t id) : PollingComponent(), id{id} {};
   void dump_config() override;
+  void update() override;
   VL53L1_Error readDistance(TofSensor *distanceSensor);
   void reset_roi(uint8_t default_center);
   void calibrateThreshold(TofSensor *distanceSensor, int number_attempts);
   void roi_calibration(uint16_t entry_threshold, uint16_t exit_threshold, Orientation orientation);
   const uint8_t id;
-  uint16_t getDistance() const;
   bool is_occupied() const { return occupancy->state; };
   ROI *roi = new ROI();
   ROI *roi_override = new ROI();
@@ -44,6 +44,7 @@ class Zone : public Component {
   void set_max_samples(uint8_t max) { max_samples = max; };
   binary_sensor::BinarySensor *occupancy = new binary_sensor::BinarySensor();
   void set_occupancy_sensor(binary_sensor::BinarySensor *sensor) { occupancy = sensor; }
+  void set_distance_sensor(sensor::Sensor *sensor) { distance_sensor = sensor; }
 
  protected:
   int getOptimizedValues(int *values, int sum, int size);
@@ -53,6 +54,7 @@ class Zone : public Component {
   uint16_t min_distance;
   std::vector<uint16_t> samples;
   uint8_t max_samples;
+  sensor::Sensor *distance_sensor{nullptr};
 };
 }  // namespace roode
 }  // namespace esphome

--- a/components/roode/zone.h
+++ b/components/roode/zone.h
@@ -42,7 +42,7 @@ class Zone {
   ROI *roi_override = new ROI();
   Threshold *threshold = new Threshold();
   void set_max_samples(uint8_t max) { max_samples = max; };
-  binary_sensor::BinarySensor *occupancy{};
+  binary_sensor::BinarySensor *occupancy = new binary_sensor::BinarySensor();
   void set_occupancy_sensor(binary_sensor::BinarySensor *sensor) { occupancy = sensor; }
 
  protected:

--- a/components/roode/zone.h
+++ b/components/roode/zone.h
@@ -27,10 +27,10 @@ struct Threshold {
   void set_max_percentage(uint8_t max) { this->max_percentage = max; }
 };
 
-class Zone {
+class Zone : public Component {
  public:
   explicit Zone(uint8_t id) : id{id} {};
-  void dump_config() const;
+  void dump_config() override;
   VL53L1_Error readDistance(TofSensor *distanceSensor);
   void reset_roi(uint8_t default_center);
   void calibrateThreshold(TofSensor *distanceSensor, int number_attempts);

--- a/components/vl53l1x/__init__.py
+++ b/components/vl53l1x/__init__.py
@@ -59,18 +59,21 @@ def int_with_unit(*args, **kwargs):
     return int_validator
 
 
+def none_to_empty(default: Any = None):
+    def validator(value):
+        if value is None:
+            return {} if default is None else default
+        return value
+
+    return validator
+
+
 def NullableSchema(*args, default: Any = None, **kwargs):
     """
     Same as Schema but will convert nulls to empty objects. Useful when all the schema keys are optional.
     Allows YAML lines to be commented out leaving an "empty dict" which is mistakenly parsed as None.
     """
-
-    def none_to_empty(value):
-        if value is None:
-            return {} if default is None else default
-        raise cv.Invalid("Expected none")
-
-    return cv.Any(cv.Schema(*args, **kwargs), none_to_empty)
+    return cv.All(none_to_empty(default), cv.Schema(*args, **kwargs))
 
 
 CONFIG_SCHEMA = (

--- a/peopleCounter32.yaml
+++ b/peopleCounter32.yaml
@@ -113,15 +113,17 @@ binary_sensor:
 
 sensor:
   - platform: roode
-    id: roode_sensors
-    distance_entry:
-      name: $friendly_name distance zone 0
-      filters:
-        - delta: 100
-    distance_exit:
-      name: $friendly_name distance zone 1
-      filters:
-        - delta: 100
+    zones:
+      entry:
+        distance:
+          name: $friendly_name Entry Distance
+          filters:
+            - delta: 100
+      exit:
+        distance:
+          name: $friendly_name Exit Distance
+          filters:
+            - delta: 100
     max_threshold_entry:
       name: $friendly_name max zone 0
     max_threshold_exit:

--- a/peopleCounter32Dev.yaml
+++ b/peopleCounter32Dev.yaml
@@ -109,17 +109,17 @@ binary_sensor:
 
 sensor:
   - platform: roode
-    id: roode_sensors
-    distance_entry:
-      name: $friendly_name distance zone 0
-      id: entryDist
-      filters:
-        - delta: 100
-    distance_exit:
-      name: $friendly_name distance zone 1
-      id: exitDist
-      filters:
-        - delta: 100
+    zones:
+      entry:
+        distance:
+          name: $friendly_name Entry Distance
+          filters:
+            - delta: 100
+      exit:
+        distance:
+          name: $friendly_name Exit Distance
+          filters:
+            - delta: 100
     max_threshold_entry:
       name: $friendly_name max zone 0
     max_threshold_exit:

--- a/peopleCounter8266.yaml
+++ b/peopleCounter8266.yaml
@@ -101,15 +101,17 @@ binary_sensor:
 
 sensor:
   - platform: roode
-    id: roode_sensors
-    distance_entry:
-      name: $friendly_name distance zone 0
-      filters:
-        - delta: 100
-    distance_exit:
-      name: $friendly_name distance zone 1
-      filters:
-        - delta: 100
+    zones:
+      entry:
+        distance:
+          name: $friendly_name Entry Distance
+          filters:
+            - delta: 100
+      exit:
+        distance:
+          name: $friendly_name Exit Distance
+          filters:
+            - delta: 100
     max_threshold_entry:
       name: $friendly_name max zone 0
     max_threshold_exit:

--- a/peopleCounter8266Dev.yaml
+++ b/peopleCounter8266Dev.yaml
@@ -105,17 +105,17 @@ binary_sensor:
 
 sensor:
   - platform: roode
-    id: roode_sensors
-    distance_entry:
-      name: $friendly_name distance zone 0
-      id: entryDist
-      filters:
-        - delta: 100
-    distance_exit:
-      name: $friendly_name distance zone 1
-      id: exitDist
-      filters:
-        - delta: 100
+    zones:
+      entry:
+        distance:
+          name: $friendly_name Entry Distance
+          filters:
+            - delta: 100
+      exit:
+        distance:
+          name: $friendly_name Exit Distance
+          filters:
+            - delta: 100
     max_threshold_entry:
       name: $friendly_name max zone 0
     max_threshold_exit:


### PR DESCRIPTION
- `Zones` are now the polling component(s) instead of `Roode`.
- Refactored sensor config to have `zones.entry/exit` instead of duplicate entries with different suffixes.
   https://github.com/Lyr3x/Roode/compare/dev...CarsonF:distance-to-zone?expand=1#diff-79d9beac237fb837d56ad984858585e78859deaab40346372801d9d382b82e02L116-R126
  See diff for example.
- Fixed occupancy sensor usage when user doesn't define them.
   We'll use the zone ones internally, but skip the roode union one.

Will update other sensors in future PR.