### PR TITLE
Refactor vl531lx error sensor

### DIFF
--- a/ci/common.yaml
+++ b/ci/common.yaml
@@ -65,8 +65,9 @@ sensor:
       name: $friendly_name ROI height zone 1
     roi_width_exit:
       name: $friendly_name ROI width zone 1
-    sensor_status:
-      name: Sensor Status
+  - platform: vl53l1x
+    error:
+      name: Sensor Error
 
 text_sensor:
   - platform: roode

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -36,34 +36,13 @@ void Roode::setup() {
 void Roode::loop() {
   // unsigned long start = micros();
   this->current_zone->readDistance(distanceSensor);
-  // uint16_t samplingDistance = sampling(this->current_zone);
   path_tracking(this->current_zone);
-  handle_sensor_status();
   this->current_zone = this->current_zone == this->entry ? this->exit : this->entry;
   // ESP_LOGI("Experimental", "Entry zone: %d, exit zone: %d",
   // entry->getDistance(Roode::distanceSensor, Roode::sensor_status),
   // exit->getDistance(Roode::distanceSensor, Roode::sensor_status)); unsigned
   // long end = micros(); unsigned long delta = end - start; ESP_LOGI("Roode
   // loop", "loop took %lu microseconds", delta);
-}
-
-bool Roode::handle_sensor_status() {
-  bool check_status = false;
-  if (last_sensor_status != sensor_status && sensor_status == VL53L1_ERROR_NONE) {
-    if (status_sensor != nullptr) {
-      status_sensor->publish_state(sensor_status);
-    }
-    check_status = true;
-  }
-  if (sensor_status < 28 && sensor_status != VL53L1_ERROR_NONE) {
-    ESP_LOGE(TAG, "Ranging failed with an error. status: %d", sensor_status);
-    status_sensor->publish_state(sensor_status);
-    check_status = false;
-  }
-
-  last_sensor_status = sensor_status;
-  sensor_status = VL53L1_ERROR_NONE;
-  return check_status;
 }
 
 void Roode::path_tracking(const Zone *const zone) {

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -111,10 +111,7 @@ class Roode : public Component {
   text_sensor::TextSensor *version_sensor;
   text_sensor::TextSensor *entry_exit_event_sensor;
 
-  VL53L1_Error last_sensor_status = VL53L1_ERROR_NONE;
-  VL53L1_Error sensor_status = VL53L1_ERROR_NONE;
   void path_tracking(const Zone *zone);
-  bool handle_sensor_status();
   void calibrateDistance();
   void calibrate_zones();
   const RangingMode *determine_ranging_mode(uint16_t average_entry_zone_distance,

--- a/components/roode/sensor.py
+++ b/components/roode/sensor.py
@@ -5,11 +5,8 @@ import esphome.config_validation as cv
 from esphome.components.sensor import new_sensor, sensor_schema
 from esphome.components import sensor
 from esphome.const import (
-    ICON_ARROW_EXPAND_VERTICAL,
-    ICON_NEW_BOX,
     ICON_RULER,
     STATE_CLASS_MEASUREMENT,
-    UNIT_EMPTY,
     ENTITY_CATEGORY_DIAGNOSTIC,
 )
 from . import (
@@ -32,7 +29,6 @@ CONF_ROI_HEIGHT_entry = "roi_height_entry"
 CONF_ROI_WIDTH_entry = "roi_width_entry"
 CONF_ROI_HEIGHT_exit = "roi_height_exit"
 CONF_ROI_WIDTH_exit = "roi_width_exit"
-SENSOR_STATUS = "sensor_status"
 
 ZONE_SCHEMA = NullableSchema(
     {
@@ -111,11 +107,6 @@ CONFIG_SCHEMA = cv.Schema(
             state_class=STATE_CLASS_MEASUREMENT,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
-        cv.Optional(SENSOR_STATUS): sensor.sensor_schema(
-            icon="mdi:check-circle",
-            accuracy_decimals=0,
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ),
     }
 )
 
@@ -149,9 +140,6 @@ async def to_code(config: Dict):
     if CONF_ROI_WIDTH_exit in config:
         count = await sensor.new_sensor(config[CONF_ROI_WIDTH_exit])
         cg.add(var.set_exit_roi_width_sensor(count))
-    if SENSOR_STATUS in config:
-        count = await sensor.new_sensor(config[SENSOR_STATUS])
-        cg.add(var.set_sensor_status_sensor(count))
 
 
 async def to_code_zone(name: str, config: Dict, roode: cg.Pvariable):

--- a/components/roode/zone.cpp
+++ b/components/roode/zone.cpp
@@ -13,11 +13,10 @@ void Zone::dump_config() {
 }
 
 VL53L1_Error Zone::readDistance(TofSensor *distanceSensor) {
-  last_sensor_status = sensor_status;
-
-  auto result = distanceSensor->read_distance(roi, sensor_status);
+  VL53L1_Error status;
+  auto result = distanceSensor->read_distance(roi, status);
   if (!result.has_value()) {
-    return sensor_status;
+    return status;
   }
 
   last_distance = result.value();
@@ -29,7 +28,7 @@ VL53L1_Error Zone::readDistance(TofSensor *distanceSensor) {
 
   occupancy->publish_state(min_distance < threshold->max && min_distance > threshold->min);
 
-  return sensor_status;
+  return status;
 }
 
 /**

--- a/components/roode/zone.h
+++ b/components/roode/zone.h
@@ -48,8 +48,6 @@ class Zone : public PollingComponent {
 
  protected:
   int getOptimizedValues(int *values, int sum, int size);
-  VL53L1_Error last_sensor_status = VL53L1_ERROR_NONE;
-  VL53L1_Error sensor_status = VL53L1_ERROR_NONE;
   uint16_t last_distance;
   uint16_t min_distance;
   std::vector<uint16_t> samples;

--- a/components/vl53l1x/__init__.py
+++ b/components/vl53l1x/__init__.py
@@ -25,6 +25,8 @@ MULTI_CONF = False  # TODO enable when we support multiple addresses
 vl53l1x_ns = cg.esphome_ns.namespace("vl53l1x")
 VL53L1X = vl53l1x_ns.class_("VL53L1X", cg.Component)
 
+CONF_VL53L1X_ID = "vl53l1x_id"
+
 CONF_AUTO = "auto"
 CONF_CALIBRATION = "calibration"
 CONF_RANGING_MODE = "ranging"

--- a/components/vl53l1x/sensor.py
+++ b/components/vl53l1x/sensor.py
@@ -1,0 +1,31 @@
+from typing import Dict
+
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components.sensor import new_sensor, sensor_schema
+from esphome.const import (
+    ENTITY_CATEGORY_DIAGNOSTIC,
+)
+from . import VL53L1X, CONF_VL53L1X_ID
+
+DEPENDENCIES = ["vl53l1x"]
+
+CONF_ERROR = "error"
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_VL53L1X_ID): cv.use_id(VL53L1X),
+        cv.Optional(CONF_ERROR): sensor_schema(
+            icon="mdi:alert-decagram",
+            accuracy_decimals=0,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
+    }
+)
+
+
+async def to_code(config: Dict):
+    var = await cg.get_variable(config[CONF_VL53L1X_ID])
+
+    if CONF_ERROR in config:
+        cg.add(var.set_error_sensor(await new_sensor(config[CONF_ERROR])))

--- a/components/vl53l1x/vl53l1x.cpp
+++ b/components/vl53l1x/vl53l1x.cpp
@@ -3,6 +3,9 @@
 namespace esphome {
 namespace vl53l1x {
 
+#define ERROR(message, ...) \
+  ESP_LOGE(TAG, message ". Error code: %d", ##__VA_ARGS__, status)
+
 void VL53L1X::dump_config() {
   ESP_LOGCONFIG(TAG, "VL53L1X:");
   LOG_I2C_DEVICE(this);
@@ -34,7 +37,7 @@ void VL53L1X::setup() {
     ESP_LOGI(TAG, "Setting offset calibration to %d", this->offset.value());
     status = this->sensor.SetOffsetInMm(this->offset.value());
     if (status != VL53L1_ERROR_NONE) {
-      ESP_LOGE(TAG, "Could not set offset calibration, error code: %d", status);
+      ERROR("Could not set offset calibration");
       this->mark_failed();
       return;
     }
@@ -44,7 +47,7 @@ void VL53L1X::setup() {
     ESP_LOGI(TAG, "Setting crosstalk calibration to %d", this->xtalk.value());
     status = this->sensor.SetXTalk(this->xtalk.value());
     if (status != VL53L1_ERROR_NONE) {
-      ESP_LOGE(TAG, "Could not set crosstalk calibration, error code: %d", status);
+      ERROR("Could not set crosstalk calibration");
       this->mark_failed();
       return;
     }
@@ -63,7 +66,7 @@ VL53L1_Error VL53L1X::init() {
     ESP_LOGD(TAG, "Setting different address");
     status = sensor.SetI2CAddress(address_ << 1);
     if (status != VL53L1_ERROR_NONE) {
-      ESP_LOGE(TAG, "Failed to change address. Error: %d", status);
+      ERROR("Failed to change address");
       return status;
     }
   }
@@ -76,7 +79,7 @@ VL53L1_Error VL53L1X::init() {
   ESP_LOGD(TAG, "Found device, initializing...");
   status = sensor.Init();
   if (status != VL53L1_ERROR_NONE) {
-    ESP_LOGE(TAG, "Could not initialize device, error code: %d", status);
+    ERROR("Could not initialize device");
     return status;
   }
 
@@ -109,7 +112,7 @@ VL53L1_Error VL53L1X::wait_for_boot() {
 VL53L1_Error VL53L1X::get_device_state(uint8_t *device_state) {
   VL53L1_Error status = sensor.GetBootState(device_state);
   if (status != VL53L1_ERROR_NONE) {
-    ESP_LOGE(TAG, "Failed to read device state. error: %d", status);
+    ERROR("Failed to read device state");
     return status;
   }
 
@@ -133,17 +136,17 @@ void VL53L1X::set_ranging_mode(const RangingMode *mode) {
 
   auto status = this->sensor.SetDistanceMode(mode->mode);
   if (status != VL53L1_ERROR_NONE) {
-    ESP_LOGE(TAG, "Could not set distance mode: %d, error code: %d", mode->mode, status);
+    ERROR("Could not set distance mode: %d", mode->mode);
   }
 
   status = this->sensor.SetTimingBudgetInMs(mode->timing_budget);
   if (status != VL53L1_ERROR_NONE) {
-    ESP_LOGE(TAG, "Could not set timing budget: %d ms, error code: %d", mode->timing_budget, status);
+    ERROR("Could not set timing budget: %d ms", mode->timing_budget);
   }
 
   status = this->sensor.SetInterMeasurementInMs(mode->delay_between_measurements);
   if (status != VL53L1_ERROR_NONE) {
-    ESP_LOGE(TAG, "Could not set measurement delay: %d ms, error code: %d", mode->delay_between_measurements, status);
+    ERROR("Could not set measurement delay: %d ms", mode->delay_between_measurements);
   }
 
   this->ranging_mode = mode;
@@ -163,12 +166,12 @@ optional<uint16_t> VL53L1X::read_distance(ROI *roi, VL53L1_Error &status) {
 
     status = this->sensor.SetROI(roi->width, roi->height);
     if (status != VL53L1_ERROR_NONE) {
-      ESP_LOGE(TAG, "Could not set ROI width/height, error code: %d", status);
+      ERROR("Could not set ROI width/height");
       return {};
     }
     status = this->sensor.SetROICenter(roi->center);
     if (status != VL53L1_ERROR_NONE) {
-      ESP_LOGE(TAG, "Could not set ROI center, error code: %d", status);
+      ERROR("Could not set ROI center");
       return {};
     }
     last_roi = roi;
@@ -182,7 +185,7 @@ optional<uint16_t> VL53L1X::read_distance(ROI *roi, VL53L1_Error &status) {
   while (!dataReady) {
     status = this->sensor.CheckForDataReady(&dataReady);
     if (status != VL53L1_ERROR_NONE) {
-      ESP_LOGE(TAG, "Failed to check if data is ready, error code: %d", status);
+      ERROR("Failed to check if data is ready");
       return {};
     }
     delay(1);
@@ -193,19 +196,19 @@ optional<uint16_t> VL53L1X::read_distance(ROI *roi, VL53L1_Error &status) {
   uint16_t distance;
   status = this->sensor.GetDistanceInMm(&distance);
   if (status != VL53L1_ERROR_NONE) {
-    ESP_LOGE(TAG, "Could not get distance, error code: %d", status);
+    ERROR("Could not get distance");
     return {};
   }
 
   // After reading the results reset the interrupt to be able to take another measurement
   status = this->sensor.ClearInterrupt();
   if (status != VL53L1_ERROR_NONE) {
-    ESP_LOGE(TAG, "Could not clear interrupt, error code: %d", status);
+    ERROR("Could not clear interrupt");
     return {};
   }
   status = this->sensor.StopRanging();
   if (status != VL53L1_ERROR_NONE) {
-    ESP_LOGE(TAG, "Could not stop ranging, error code: %d", status);
+    ERROR("Could not stop ranging");
     return {};
   }
 

--- a/components/vl53l1x/vl53l1x.cpp
+++ b/components/vl53l1x/vl53l1x.cpp
@@ -4,7 +4,8 @@ namespace esphome {
 namespace vl53l1x {
 
 #define ERROR(message, ...) \
-  ESP_LOGE(TAG, message ". Error code: %d", ##__VA_ARGS__, status)
+  ESP_LOGE(TAG, message ". Error code: %d", ##__VA_ARGS__, status); \
+  this->publish_error(status)
 
 void VL53L1X::dump_config() {
   ESP_LOGCONFIG(TAG, "VL53L1X:");
@@ -214,6 +215,12 @@ optional<uint16_t> VL53L1X::read_distance(ROI *roi, VL53L1_Error &status) {
 
   ESP_LOGV(TAG, "Finished distance read: %d", distance);
   return {distance};
+}
+
+void VL53L1X::publish_error(VL53L1_Error error) {
+  if (error_sensor != nullptr) {
+    error_sensor->publish_state(error);
+  }
 }
 
 }  // namespace vl53l1x

--- a/components/vl53l1x/vl53l1x.h
+++ b/components/vl53l1x/vl53l1x.h
@@ -35,12 +35,13 @@ class VL53L1X : public i2c::I2CDevice, public Component {
   void set_offset(int16_t val) { this->offset = val; }
   void set_xtalk(uint16_t val) { this->xtalk = val; }
   void set_timeout(uint16_t val) { this->timeout = val; }
+   void set_error_sensor(sensor::Sensor *error_sensor_) { this->error_sensor = error_sensor_; }
 
  protected:
   VL53L1X_ULD sensor;
   optional<GPIOPin *> xshut_pin{};
   optional<InternalGPIOPin *> interrupt_pin{};
-  const RangingMode * ranging_mode{};
+  const RangingMode *ranging_mode{};
   /** Mode from user config, which can be get/set independently of current mode */
   optional<const RangingMode *> ranging_mode_override{};
   optional<int16_t> offset{};
@@ -51,6 +52,8 @@ class VL53L1X : public i2c::I2CDevice, public Component {
   VL53L1_Error init();
   VL53L1_Error wait_for_boot();
   VL53L1_Error get_device_state(uint8_t *device_state);
+  void publish_error(VL53L1_Error error);
+  sensor::Sensor *error_sensor{nullptr};
 };
 
 }  // namespace vl53l1x

--- a/peopleCounter32.yaml
+++ b/peopleCounter32.yaml
@@ -140,8 +140,9 @@ sensor:
       name: $friendly_name ROI height zone 1
     roi_width_exit:
       name: $friendly_name ROI width zone 1
-    sensor_status:
-      name: Sensor Status
+  - platform: vl53l1x
+    error:
+      name: Sensor Error
   - platform: wifi_signal
     name: $friendly_name RSSI
     update_interval: 60s

--- a/peopleCounter32Dev.yaml
+++ b/peopleCounter32Dev.yaml
@@ -136,8 +136,9 @@ sensor:
       name: $friendly_name ROI height zone 1
     roi_width_exit:
       name: $friendly_name ROI width zone 1
-    sensor_status:
-      name: Sensor Status
+  - platform: vl53l1x
+    error:
+      name: Sensor Error
 
   - platform: wifi_signal
     name: $friendly_name RSSI

--- a/peopleCounter8266.yaml
+++ b/peopleCounter8266.yaml
@@ -128,8 +128,9 @@ sensor:
       name: $friendly_name ROI height zone 1
     roi_width_exit:
       name: $friendly_name ROI width zone 1
-    sensor_status:
-      name: Sensor Status
+  - platform: vl53l1x
+    error:
+      name: Sensor Error
 
   - platform: wifi_signal
     name: $friendly_name RSSI

--- a/peopleCounter8266Dev.yaml
+++ b/peopleCounter8266Dev.yaml
@@ -132,8 +132,9 @@ sensor:
       name: $friendly_name ROI height zone 1
     roi_width_exit:
       name: $friendly_name ROI width zone 1
-    sensor_status:
-      name: Sensor Status
+  - platform: vl53l1x
+    error:
+      name: Sensor Error
 
   - platform: wifi_signal
     name: $friendly_name RSSI


### PR DESCRIPTION
```yaml
sensor:
  - platform: vl53l1x
    error:
      name: Sensor Error Code
```

Currently once an error is published it is not automatically reset. This was an oversight, but maybe it's fine? Errors should never be hit, so if they are they'll at least require a restart/reconfig so they'll be reset then...