### PR TITLE
fix-release-workflow

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -37,6 +37,7 @@ jobs:
           draft: false
           prerelease: false
           generateReleaseNotes: true
+          skipIfReleaseExists: true
 
       - name: Discord notification
         uses: Ilshidur/action-discord@master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-## 1.5.1
+## 1.5.4
 
-
+- Fix ESPHome 2026.2+ compatibility by migrating ESP8266 configurations to new platform format
+- Update CI configurations and example files to use separate `esp8266:` block instead of deprecated `platform:` key
+- Fix release workflow to skip creating releases that already exist
 
 ## 1.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix ESPHome 2026.2+ compatibility by migrating ESP8266 configurations to new platform format
 - Update CI configurations and example files to use separate `esp8266:` block instead of deprecated `platform:` key
+- Fix Wire library dependency for VL53L1X_ULD to resolve build errors on ESP32
 - Fix release workflow to skip creating releases that already exist
 
 ## 1.5.0

--- a/ci/esp8266.yaml
+++ b/ci/esp8266.yaml
@@ -1,7 +1,6 @@
 <<: !include common.yaml
-esphome:
-  name: $devicename
-  platform: ESP8266
+
+esp8266:
   board: d1_mini
 
 i2c:

--- a/components/vl53l1x/__init__.py
+++ b/components/vl53l1x/__init__.py
@@ -108,6 +108,7 @@ CONFIG_SCHEMA = (
 
 
 async def to_code(config: Dict):
+    cg.add_library("Wire", None)  # Required for VL53L1X_ULD to find Wire.h
     cg.add_library("rneurink", "1.2.3", "VL53L1X_ULD")
 
     vl53l1x = cg.new_Pvariable(config[CONF_ID])

--- a/peopleCounter8266.yaml
+++ b/peopleCounter8266.yaml
@@ -11,7 +11,8 @@ external_components:
 
 esphome:
   name: $devicename
-  platform: ESP8266
+
+esp8266:
   board: d1_mini
 
 wifi:

--- a/peopleCounter8266Dev.yaml
+++ b/peopleCounter8266Dev.yaml
@@ -8,7 +8,8 @@ external_components:
 
 esphome:
   name: $devicename
-  platform: ESP8266
+
+esp8266:
   board: d1_mini
 
 wifi:


### PR DESCRIPTION
- Migrate ESP8266 configurations from deprecated platform: key
to new esp8266: block format
- Fix release workflow to prevent failures when release already
 exists

**Changes**

- ci/esp8266.yaml - Use separate esp8266: block instead of
platform: ESP8266 in esphome: block
- peopleCounter8266.yaml - Same migration for user example
- peopleCounter8266Dev.yaml - Same migration for dev example
- create_release.yml - Add skipIfReleaseExists: true to prevent
 422 errors
- CHANGELOG.md - Update to version 1.5.4