### PR TITLE
Fix crash in VL53L1X::dump_config() when optional pins are not configured

### DIFF
--- a/components/vl53l1x/vl53l1x.cpp
+++ b/components/vl53l1x/vl53l1x.cpp
@@ -15,8 +15,12 @@ void VL53L1X::dump_config() {
   if (xtalk.has_value()) {
     ESP_LOGCONFIG(TAG, "  XTalk: %dcps", this->xtalk.value());
   }
-  LOG_PIN("  Interrupt Pin: ", this->interrupt_pin.value());
-  LOG_PIN("  XShut Pin: ", this->xshut_pin.value());
+  if (this->interrupt_pin.has_value()) {
+    LOG_PIN("  Interrupt Pin: ", this->interrupt_pin.value());
+  }
+  if (this->xshut_pin.has_value()) {
+    LOG_PIN("  XShut Pin: ", this->xshut_pin.value());
+  }
 }
 
 void VL53L1X::setup() {


### PR DESCRIPTION
## Summary

- Guard `interrupt_pin` and `xshut_pin` `.value()` calls in `dump_config()` with `.has_value()` checks
- Prevents `std::bad_optional_access` → `abort()` → boot loop when these optional pins are not configured
- Consistent with how `offset` and `xtalk` optionals are already guarded in the same function

## Problem

When `interrupt_pin` or `xshut_pin` are not set in the YAML configuration, `dump_config()` unconditionally calls `.value()` on empty `std::optional` members (line 18-19 of `vl53l1x.cpp`). This throws `std::bad_optional_access`, which triggers `abort()` and a reboot — causing an infinite boot loop.

This is particularly problematic when the VL53L1X sensor fails to initialize (e.g. I2C timeout), since `dump_config()` is still called after a failed setup.

Tested on ESP32-POE with ESPHome 2026.3.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)